### PR TITLE
Add submit desc features with first pass at running outside shared fs

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -1,10 +1,10 @@
-- It is recommended to use the dedicated snakemake profile for HTCondor, which you can find [here](https://github.com/Snakemake-Profiles/htcondor).
-- This plugin currently only supports job submission with a shared file system.
-- The jobs use the python binary of the environment that the user had when starting snakemake as the executable.
+# Plugin Configuration
+
+## Basic
+
+- This plugin currently supports job submission with a shared file system, with experimental support for pools without shared filesystems (such as the OSPool).
 - Error messages, the output of stdout and log files are written to `htcondor-jobdir` (see in the usage section above).
 - The job directive `threads` is used to set `request_cpu` command for HTCondor.
-- As default, the jobs will be executed with the same set of environment variables that the user had at submit time. 
-  If you don't want this behavior, set the following in resources `getenv: False`.
 - For the job status, this plugin reports the values of the [job ClassAd Attribute](https://htcondor.readthedocs.io/en/latest/classad-attributes/job-classad-attributes.html) `JobStatus`.
 - To determine whether a job was successful, this plugin relies on `htcondor.Schedd.history` (see [API reference](https://htcondor.readthedocs.io/en/latest/apis/python-bindings/api/htcondor.html)) and checks the values of the [job ClassAd Attribute](https://htcondor.readthedocs.io/en/latest/classad-attributes/job-classad-attributes.html) `ExitCode`.
 
@@ -16,5 +16,45 @@ The following [submit description file commands](https://htcondor.readthedocs.io
 | `environment`     | `request_disk`   | `require_gpus`            | `allowed_execute_duration` |
 | `input`           | `request_memory` | `gpus_minimum_capability` | `allowed_job_duration`     |
 | `max_materialize` | `requirements`   | `gpus_minimum_memory`     | `retry_until`              |
-| `max_idle`        |                  | `gpus_minimum_runtime`    |                            |
-|                   |                  | `cuda_version`            |                            |
+| `max_idle`        | `classad_<foo>`**| `gpus_minimum_runtime`    |                            |
+| `job_wrapper`*    |                  | `cuda_version`            |                            |
+| `universe`        |                  |                           |                            |
+
+
+\* A custom-defined `job_wrapper` resource will be used as the HTCondor executable for the job. It can be used for environment setup, but must pass all arguments
+  to snakemake on the EP. For example, the following is a valid bash script wrapper:
+```bash
+#!/bin/bash
+
+# Fail early if there's an issue
+set -e
+
+# When .cache files are created, they need to know where HOME is to write there.
+# In this case, that should be the HTCondor scratch dir the job is executing in.
+export HOME=$(pwd)
+
+# Pass any arguments to Snakemake
+snakemake "$@"
+```
+
+\*\* Custom ClassAds can be defined using the `classad_` prefix as a custom job resource. For example, to define the ClassAd `+MyClassAd`, define `classad_MyClassAd` in
+the job's resources.
+
+## Jobs Without Shared Filesystems
+
+Support for jobs without a shared filesystem is preliminary and experimental.
+
+As such, it currently imposes limitations on the structure of your data on the Access Point (AP), as well as the use of a job wrapper (you can use the previous example).
+It is also highly recommended that you use containers to bring a runtime execution environment along with the job, which at a minimum must contain Python and Snakemake.
+
+To run a workflow across Execution Points (EPs) that don't share a filesystem, modify the snakemake invocation with `--shared-fs-usage none`:
+```bash
+snakemake --executor htcondor --shared-fs-usage none
+```
+Doing so will invoke the HTCondor file transfer mechanism to move files from the AP to the EPs responsible for running each job.
+
+There is currently a limitation that files being transferred (e.g. Snakefile, config files, input data) must have the same scope on both the AP/EP, and in
+any Snakefile/Config file declarations. That is, if your configuration yaml file specifies an input directory called `my_data/`, the directory must be at
+the same location the job is submitted from, and it must arrive at the EP as `my_data/`. Because of this, a configured input directory like `../../my_data/`
+cannot work, because Snakemake at the EP will attempt to find `../../my_data` on its own filesystem where the directory will have been flattened to
+`my_data/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "snakemake-executor-plugin-htcondor"
 version = "0.1.2"
-description = "A Snakemake executor plugin for submitting jobs to a HTCondor cluster."
-authors = [ "Jannis Speer <jannis.speer@tutanota.com>",]
+description = "A Snakemake executor plugin for submitting jobs to an HTCondor cluster."
+authors = [ "Jannis Speer <jannis.speer@tutanota.com>", "Justin Hiemstra <jhiemstra@wisc.edu>",]
 readme = "README.md"
-repository = "https://github.com/jannisspeer/snakemake-executor-plugin-htcondor"
+repository = "https://github.com/htcondor/snakemake-executor-plugin-htcondor"
 documentation = "https://snakemake.github.io/snakemake-plugin-catalog/plugins/executor/htcondor.html"
 
 [tool.poetry.dependencies]

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -12,6 +12,7 @@ from snakemake_interface_executor_plugins.jobs import (
 from snakemake_interface_common.exceptions import WorkflowError  # noqa
 
 import htcondor
+import traceback
 from os.path import join, basename, abspath, dirname
 from os import makedirs, sep
 import re
@@ -269,8 +270,10 @@ class Executor(RemoteExecutor):
                 raise CredsError("Credentials not found for this workflow")
             submit_result = schedd.submit(submit_description)
         except CredsError as ce:
+            traceback.print_exc()
             print(f"CredsError occurred: {ce}")
         except Exception as e:
+            traceback.print_exc()
             raise WorkflowError(f"Failed to submit HTCondor job: {e}")
 
         self.logger.info(

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -132,7 +132,6 @@ class Executor(RemoteExecutor):
                 top_most_input_directories = {path.split(sep)[0] for path in job.input}
                 submit_dict["transfer_input_files"] = ", ".join(sorted(top_most_input_directories))
 
-
             if self.workflow.configfiles:
                 # Note that when we transfer the config file(s), we'll pass Condor an absolute path, but we need to
                 # modify the job args to use only the file name(s) when execution begins, because the configfile(s)

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -229,6 +229,12 @@ class Executor(RemoteExecutor):
         # Name the jobs in the queue something that tells us what the job is
         submit_dict["batch_name"] = f"{job.name}-{job.jobid}"
 
+        # Check any custom classads
+        for key in job.resources.keys():
+            if key.startswith("classad_"):
+                classad_key = key.removeprefix("classad_") + "+"
+                submit_dict[classad_key] = job.resources.get(key)
+
         # HTCondor submit description
         self.logger.debug(f"HTCondor submit subscription: {submit_dict}")
         submit_description = htcondor.Submit(submit_dict)

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -144,6 +144,9 @@ class Executor(RemoteExecutor):
             if job.resources.get(key):
                 submit_dict[key] = job.resources.get(key)
 
+        # Name the jobs in the queue something that tells us what the job is
+        submit_dict["batch_name"] = f"{job.name}-{job.jobid}"
+
         # HTCondor submit description
         self.logger.debug(f"HTCondor submit subscription: {submit_dict}")
         submit_description = htcondor.Submit(submit_dict)

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -12,8 +12,9 @@ from snakemake_interface_executor_plugins.jobs import (
 from snakemake_interface_common.exceptions import WorkflowError  # noqa
 
 import htcondor
-from os.path import join
-from os import makedirs
+from os.path import join, basename, abspath, dirname
+from os import makedirs, sep
+import re
 
 
 # Optional:
@@ -30,6 +31,16 @@ class ExecutorSettings(ExecutorSettingsBase):
             "help": "Directory where the job will create a directory to store log, "
             "output and error files.",
             "required": True,
+        },
+    )
+
+    jobwrapper: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "A job wrapper script that can be used for remote environment "
+            "setup and teardown. The script must pass any provided arguments to the "
+            "executable, e.g. `snakemake $@`.",
+            "required": False,
         },
     )
 
@@ -60,6 +71,8 @@ common_settings = CommonSettings(
     auto_deploy_default_storage_provider=True,
     # specify initial amount of seconds to sleep before checking for job status
     init_seconds_before_status_checks=0,
+    # indicate that the HTCondor executor can transfer its own files to the remote node
+    can_transfer_local_files=True,
 )
 
 
@@ -74,6 +87,7 @@ class Executor(RemoteExecutor):
 
         # jobDir: Directory where the job will tore log, output and error files.
         self.jobDir = self.workflow.executor_settings.jobdir
+        self.jobWrapper = self.workflow.executor_settings.jobwrapper
 
     def run_job(self, job: JobExecutorInterface):
         # Submitting job to HTCondor
@@ -81,8 +95,14 @@ class Executor(RemoteExecutor):
         # Creating directory to store log, output and error files
         makedirs(self.jobDir, exist_ok=True)
 
-        job_exec = self.get_python_executable()
-        job_args = self.format_job_exec(job).removeprefix(job_exec + " ")
+        if self.jobWrapper:
+            job_exec = basename(self.jobWrapper)
+            # The wrapper script will take as input all snakemake arguments, so we assume
+            # it contains something like `snakemake $@`
+            job_args = self.format_job_exec(job).removeprefix("python -m snakemake ")
+        else:
+            job_exec = self.get_python_executable()
+            job_args = self.format_job_exec(job).removeprefix(job_exec + " ")
 
         # HTCondor cannot handle single quotes
         if "'" in job_args:
@@ -102,11 +122,46 @@ class Executor(RemoteExecutor):
             "request_cpus": str(job.threads),
         }
 
+        # If we're not using a shared filesystem, we need to setup transfers
+        # for any job wrapper, config files, input files, etc
+        if not self.workflow.storage_settings.shared_fs_usage:
+            if job.input:
+                # When snakemake passes its input args to the executable, it does so using the path relative
+                # to the specified input directory, e.g. `input/foo/bar`, so we need to transfer the top-most
+                # input directories the will contain any subdirectories/files needed by the job.
+                top_most_input_directories = {path.split(sep)[0] for path in job.input}
+                submit_dict["transfer_input_files"] = ", ".join(sorted(top_most_input_directories))
+
+
+            if self.workflow.configfiles:
+                # Note that when we transfer the config file(s), we'll pass Condor an absolute path, but we need to
+                # modify the job args to use only the file name(s) when execution begins, because the configfile(s)
+                # will be accessed from the job's scratch dir.
+                config_fnames = []
+                for fpath in self.workflow.configfiles:
+                    fname = basename(fpath)
+                    config_fnames.append(fname)
+                config_arg = " ".join(config_fnames)
+
+                configfiles_pattern = r"--configfiles .*?(?=( --|$))"
+                submit_dict["arguments"] = re.sub(configfiles_pattern, f"--configfiles {config_arg}", submit_dict["arguments"])
+
+                if submit_dict["transfer_input_files"]:
+                    submit_dict["transfer_input_files"] += ", " + ", ".join(str(path) for path in self.workflow.configfiles)
+                else:
+                    submit_dict["transfer_input_files"] = ", ".join(str(path) for path in self.workflow.configfiles)
+
+            if job.output:
+                # For outputs, we only care about the parent directory, which we'll tell
+                # HTCondor to transfer back to the AP.
+                top_most_output_directories = {path.split(sep)[0] for path in job.output}
+                submit_dict["transfer_output_files"] = ", ".join(sorted(top_most_output_directories))
+
         # Basic commands
         if job.resources.get("getenv"):
             submit_dict["getenv"] = job.resources.get("getenv")
         else:
-            submit_dict["getenv"] = True
+            submit_dict["getenv"] = False
 
         for key in ["environment", "input", "max_materialize", "max_idle"]:
             if job.resources.get(key):


### PR DESCRIPTION
This is a first pass at running jobs someplace like the OSPool, where EPs do not share a common filesystem. To invoke the plugin in this mode, you can run:
```
snakemake --executor htcondor --shared-fs-usage none
```
This also requires a runtime container (containing at minimum Python/Snakemake) and a wrapper script that passes all arguments to snakemake. The plugin constructs an HTCSS submit description and passes individual snakemake job arguments to the wrapper executable, which is determines what happens on the EP.

When run without shared fs usage, the plugin will try determining which files need to be transferred to the EP (using CEDAR transfers). Due to this transfer, and the corresponding flattening of things at the EP, files referenced in the Snakefile/config.yaml must have the same scope/name on the AP as they do on the EP. This is a limitation I hope to work around eventually.