### PR TITLE
Add support for partially-shared filesystems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ documentation = "https://snakemake.github.io/snakemake-plugin-catalog/plugins/ex
 python = "^3.11"
 snakemake-interface-common = "^1.17.1"
 snakemake-interface-executor-plugins = "^9.0.0"
-htcondor = "^23.4.0"
+htcondor = "^24.5.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.2.0"

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -18,10 +18,6 @@ from os import makedirs, sep
 import re
 import sys
 
-"""
-Given a list of shared prefixes, determine whether a path is on a shared filesystem
-"""
-
 
 def is_shared_fs(in_path, shared_prefixes) -> bool:
     """

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -47,6 +47,16 @@ class ExecutorSettings(ExecutorSettingsBase):
             "required": True,
         },
     )
+    shared_fs_prefixes: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Comma-separated path prefixes shared between AP and EPs "
+            "(e.g., '/staging,/shared'). Files under these paths are accessed directly "
+            "without HTCondor transfer. Use with --shared-fs-usage none when only specific "
+            "paths (not all I/O) are shared.",
+            "required": False,
+        },
+    )
 
 # Required:
 # Specify common settings shared by various executors.
@@ -89,6 +99,129 @@ class Executor(RemoteExecutor):
 
         # jobDir: Directory where the job will tore log, output and error files.
         self.jobDir = self.workflow.executor_settings.jobdir
+
+        # Parse shared filesystem prefixes
+        self.shared_fs_prefixes = self._parse_shared_fs_prefixes(
+            self.workflow.executor_settings.shared_fs_prefixes
+        )
+
+        # Validate configuration and provide helpful guidance
+        if self.shared_fs_prefixes:
+            self._validate_shared_fs_configuration()
+
+    def _validate_shared_fs_configuration(self):
+        """Validate and warn about potentially confusing shared FS configuration."""
+        if not self.shared_fs_prefixes:
+            return  # No shared FS configured, nothing to validate
+
+        storage_settings = self.workflow.storage_settings.shared_fs_usage
+
+        # Check if user specified "none" but also configured shared prefixes
+        if not storage_settings:  # empty list or None means "none"
+            self.logger.info(
+                f"Detected partially shared filesystem: {', '.join(self.shared_fs_prefixes)}. "
+                "Files under these paths will be accessed directly at the Execution Point without HTCondor transfer."
+            )
+
+    def _parse_shared_fs_prefixes(self, prefixes_str: Optional[str]) -> List[str]:
+        """
+        Parse the comma-separated shared filesystem prefixes string.
+
+        Args:
+            prefixes_str: Comma-separated string of filesystem prefixes
+
+        Returns:
+            List of normalized filesystem prefix paths
+        """
+        if not prefixes_str:
+            return []
+
+        # Split by comma and strip whitespace/quotes
+        prefixes = [item.strip().strip("'\"") for item in prefixes_str.split(',') if item.strip()]
+
+        # Normalize paths to ensure they end with a separator for proper prefix matching
+        normalized = [join(prefix, '') for prefix in prefixes]
+
+        self.logger.debug(f"Parsed shared filesystem prefixes: {normalized}")
+        return normalized
+
+    def _get_files_for_transfer(self, job: JobExecutorInterface) -> tuple[List[str], List[str]]:
+        """
+        Determine which input and output files need to be transferred by HTCondor.
+
+        Files on shared filesystem prefixes are excluded from transfer.
+
+        Args:
+            job: The job being prepared for submission
+
+        Returns:
+            Tuple of (transfer_input_files, transfer_output_files) lists
+        """
+        transfer_input_files = []
+        transfer_output_files = []
+
+        # Add the snakefile to the transfer list if not on shared filesystem
+        snakefile = self.get_snakefile()
+        if not is_shared_fs(snakefile, self.shared_fs_prefixes):
+            transfer_input_files.append(str(snakefile))
+
+        # Process input files
+        if job.input:
+            inputs = [input for input in job.input]
+
+            # Preserve relative paths by default
+            if not job.resources.get("preserve_relative_paths", True):
+                inputs = {path.split(sep)[0] for path in inputs}
+
+            for path in inputs:
+                if path and not is_shared_fs(path, self.shared_fs_prefixes):
+                    transfer_input_files.append(str(path))
+
+        # Process config files
+        if self.workflow.configfiles:
+            for fpath in self.workflow.configfiles:
+                if fpath and not is_shared_fs(fpath, self.shared_fs_prefixes):
+                    transfer_input_files.append(str(fpath))
+
+        # Process output files
+        if job.output:
+            # Only transfer top-most output directories
+            top_most_output_directories = {path.split(sep)[0] for path in job.output}
+            for path in top_most_output_directories:
+                if path and not is_shared_fs(path, self.shared_fs_prefixes):
+                    transfer_output_files.append(str(path))
+
+        return transfer_input_files, transfer_output_files
+
+    def _prepare_config_files_for_transfer(self, job_args: str) -> tuple[str, List[str]]:
+        """
+        Prepare config files for transfer and adjust job arguments.
+
+        When config files are transferred, we need to modify the job arguments
+        to use only the file names (not full paths) since files will be in
+        the job's scratch directory on the EP.
+
+        Args:
+            job_args: Original job arguments string
+
+        Returns:
+            Tuple of (modified_job_args, config_file_names)
+        """
+        if not self.workflow.configfiles:
+            return job_args, []
+
+        config_fnames = []
+        for fpath in self.workflow.configfiles:
+            fname = basename(fpath)
+            config_fnames.append(fname)
+
+        # Modify job args to use only filenames
+        if config_fnames:
+            config_arg = " ".join(config_fnames)
+            configfiles_pattern = r"--configfiles .*?(?=( --|$))"
+            job_args = re.sub(configfiles_pattern, f"--configfiles {config_arg}", job_args)
+
+        return job_args, config_fnames
 
 
     def run_job(self, job: JobExecutorInterface):
@@ -149,65 +282,21 @@ class Executor(RemoteExecutor):
             submit_dict["should_transfer_files"] = "YES"
             submit_dict["when_to_transfer_output"] = "ON_EXIT"
 
-            # Grab our list of shared filesystem prefixes. We'll use these to determine
-            # which files HTCondor has to transfer to the EP, and which might already be accessible
-            shared_fs_prefixes = job.resources.get("shared_fs_prefixes", "")
-            shared_fs_prefixes = [item.strip() for item in shared_fs_prefixes.split(',') if item.strip()]
-            self.logger.debug(f"Shared filesystem prefixes: {shared_fs_prefixes}")
-            # Initialize the transfer input files list
-            transfer_input_files = []
+            # Determine which files need to be transferred
+            transfer_input_files, transfer_output_files = self._get_files_for_transfer(job)
 
-            # Add the snakefile to the transfer list
-            snakefile = self.get_snakefile()
-            if not is_shared_fs(snakefile, shared_fs_prefixes):
-                transfer_input_files.append(str(snakefile))
-
-            if job.input:
-                inputs = [input for input in job.input]
-
-                # When snakemake passes its input args to the executable, it does so using the path relative
-                # to the specified input directory, e.g. `input/foo/bar`. Therefore, we either need to transfer
-                # the inputs in a way that preserves paths relative to the input, or we need to transfer the entire
-                # input directory. By default, we'll preserve relative paths, but if the user specifies otherwise,
-                # we'll transfer the entire input directory.
-                if not job.resources.get("preserve_relative_paths", True):
-                    inputs = {path.split(sep)[0] for path in inputs}
-
-                for path in inputs:
-                    if path and not is_shared_fs(path, shared_fs_prefixes):
-                        transfer_input_files.append(str(path))
-
-            if self.workflow.configfiles:
-                # Note that when we transfer the config file(s), we'll pass Condor an absolute path, but we need to
-                # modify the job args to use only the file name(s) when execution begins, because the configfile(s)
-                # will be accessed from the job's scratch dir.
-                config_fnames = []
-                for fpath in self.workflow.configfiles:
-                    fname = basename(fpath)
-                    config_fnames.append(fname)
-                    if fpath and not is_shared_fs(fpath, shared_fs_prefixes):
-                        transfer_input_files.append(str(fpath))
-                config_arg = " ".join(config_fnames)
-
-                configfiles_pattern = r"--configfiles .*?(?=( --|$))"
-                submit_dict["arguments"] = re.sub(configfiles_pattern, f"--configfiles {config_arg}", submit_dict["arguments"])
+            # Adjust config file arguments if needed
+            submit_dict["arguments"], _ = self._prepare_config_files_for_transfer(
+                submit_dict["arguments"]
+            )
 
             if transfer_input_files:
                 self.logger.debug(f"Transfer input files: {transfer_input_files}")
                 submit_dict["transfer_input_files"] = ", ".join(sorted(transfer_input_files))
 
-            if job.output:
-                transfer_output_files = []
-                # For outputs, we only care about the parent directory, which we'll tell
-                # HTCondor to transfer back to the AP.
-                top_most_output_directories = {path.split(sep)[0] for path in job.output}
-                for path in top_most_output_directories:
-                    if path and not is_shared_fs(path, shared_fs_prefixes):
-                        transfer_output_files.append(str(path))
-                
-                if transfer_output_files:
-                    self.logger.debug(f"Transfer output files: {transfer_output_files}")
-                    submit_dict["transfer_output_files"] = ", ".join(sorted(transfer_output_files))
+            if transfer_output_files:
+                self.logger.debug(f"Transfer output files: {transfer_output_files}")
+                submit_dict["transfer_output_files"] = ", ".join(sorted(transfer_output_files))
 
         # Basic commands
         if job.resources.get("getenv"):

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -319,8 +319,11 @@ class Executor(RemoteExecutor):
                                 "JobStatus",
                             ],
                         )
-                        #  Storing the one event from HistoryIterator to list
-                        job_status = [next(job_status)]
+                        #  Storing the one event from history list
+                        if job_status and len(job_status) >= 1:
+                            job_status = [job_status[0]]
+                        else:
+                            raise ValueError(f"No job status found in history for HTCondor job with Cluster ID {current_job.external_jobid}.")
                 except Exception as e:
                     self.logger.warning(f"Failed to retrieve HTCondor job status: {e}")
                     # Assuming the job is still running and retry next time

--- a/tests/test_shared_fs.py
+++ b/tests/test_shared_fs.py
@@ -1,0 +1,332 @@
+"""
+Unit tests for shared filesystem prefix functionality in HTCondor executor.
+"""
+
+import pytest
+from unittest.mock import Mock, MagicMock, patch
+from os.path import join
+from snakemake_executor_plugin_htcondor import is_shared_fs, ExecutorSettings, Executor
+
+
+class TestIsSharedFs:
+    """Test the is_shared_fs helper function."""
+    
+    def test_path_on_shared_fs(self):
+        """Test that paths under shared prefixes are correctly identified."""
+        # One with trailing /, the other without
+        shared_prefixes = ["/staging/", "/shared"]
+        
+        assert is_shared_fs("/staging/user/data.txt", shared_prefixes) is True
+        assert is_shared_fs("/shared/project/file.txt", shared_prefixes) is True
+    
+    def test_path_not_on_shared_fs(self):
+        """Test that paths not under shared prefixes are correctly identified."""
+        shared_prefixes = ["/staging/", "/shared"]
+        
+        assert is_shared_fs("/home/user/data.txt", shared_prefixes) is False
+        assert is_shared_fs("input/local-file.txt", shared_prefixes) is False
+    
+    def test_empty_shared_prefixes(self):
+        """Test that no paths match when shared_prefixes is empty."""
+        shared_prefixes = []
+        
+        assert is_shared_fs("/staging/user/data.txt", shared_prefixes) is False
+        assert is_shared_fs("/any/path/file.txt", shared_prefixes) is False
+    
+    def test_normalized_paths(self):
+        """Test that paths are normalized correctly for comparison."""
+        shared_prefixes = ["/staging"]
+        
+        # Should work even if prefix doesn't end with /
+        assert is_shared_fs("/staging/user/data.txt", ["/staging"]) is True
+        
+        # Should normalize path with trailing separator
+        assert is_shared_fs("/staging/", shared_prefixes) is True
+    
+    def test_partial_match_rejected(self):
+        """Test that partial prefix matches are rejected."""
+        shared_prefixes = ["/staging"]
+        
+        # /staging2/ should not match /staging/
+        assert is_shared_fs("/staging2/user/data.txt", shared_prefixes) is False
+
+
+class TestParseSharedFsPrefixes:
+    """Test the _parse_shared_fs_prefixes method."""
+    
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+        
+        # Bind the actual method to our mock
+        self.executor._parse_shared_fs_prefixes = Executor._parse_shared_fs_prefixes.__get__(
+            self.executor, Executor
+        )
+    
+    def test_parse_single_prefix(self):
+        """Test parsing a single filesystem prefix."""
+        result = self.executor._parse_shared_fs_prefixes("/staging")
+        
+        assert len(result) == 1
+        assert result[0] == "/staging/"
+    
+    def test_parse_multiple_prefixes(self):
+        """Test parsing comma-separated prefixes."""
+        result = self.executor._parse_shared_fs_prefixes("/staging/,/shared,/data")
+        
+        assert len(result) == 3
+        assert "/staging/" in result
+        assert "/shared/" in result
+        assert "/data/" in result
+    
+    def test_parse_with_whitespace(self):
+        """Test parsing handles whitespace correctly."""
+        result = self.executor._parse_shared_fs_prefixes(" /staging/ , /shared , /data ")
+        
+        assert len(result) == 3
+        assert all(prefix.strip() == prefix for prefix in result)
+    
+    def test_parse_with_quotes(self):
+        """Test parsing removes quotes from prefixes."""
+        result = self.executor._parse_shared_fs_prefixes("'/staging/',\"/shared\"")
+        
+        assert len(result) == 2
+        assert result[0] == "/staging/"
+        assert result[1] == "/shared/"
+    
+    def test_parse_none_returns_empty_list(self):
+        """Test that None input returns empty list."""
+        result = self.executor._parse_shared_fs_prefixes(None)
+        
+        assert result == []
+    
+    def test_parse_empty_string_returns_empty_list(self):
+        """Test that empty string returns empty list."""
+        result = self.executor._parse_shared_fs_prefixes("")
+        
+        assert result == []
+    
+    def test_parse_only_whitespace_returns_empty_list(self):
+        """Test that whitespace-only string returns empty list."""
+        result = self.executor._parse_shared_fs_prefixes("   ,  , ")
+        
+        assert result == []
+
+
+class TestGetFilesForTransfer:
+    """Test the _get_files_for_transfer method."""
+    
+    def setup_method(self):
+        """Setup mock executor and job for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+        self.executor.shared_fs_prefixes = ["/staging", "/shared/"]
+        self.executor.workflow = Mock()
+        self.executor.workflow.configfiles = []
+        self.executor.get_snakefile = Mock(return_value="/home/user/Snakefile")
+        
+        # Bind the actual method to our mock
+        self.executor._get_files_for_transfer = Executor._get_files_for_transfer.__get__(
+            self.executor, Executor
+        )
+        
+        # Create mock job
+        self.job = Mock()
+        self.job.input = []
+        self.job.output = []
+        self.job.resources = Mock()
+        self.job.resources.get = Mock(return_value=True)  # Default preserve_relative_paths=True
+    
+    def test_snakefile_not_on_shared_fs(self):
+        """Test that Snakefile not on shared FS is included in transfer."""
+        transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+        
+        assert "/home/user/Snakefile" in transfer_input
+    
+    def test_snakefile_on_shared_fs(self):
+        """Test that Snakefile on shared FS is excluded from transfer."""
+        self.executor.get_snakefile = Mock(return_value="/staging/user/Snakefile")
+        
+        transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+        
+        assert "/staging/user/Snakefile" not in transfer_input
+    
+    def test_input_files_mixed_locations(self):
+        """Test handling of input files in mixed locations."""
+        self.job.input = [
+            "input/local-file.txt",
+            "/staging/user/shared-file.txt",
+            "/home/user/another-file.txt"
+        ]
+        
+        transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+        
+        # Local and home files should be transferred
+        assert "input/local-file.txt" in transfer_input
+        assert "/home/user/another-file.txt" in transfer_input
+        
+        # Staging file should not be transferred
+        assert "/staging/user/shared-file.txt" not in transfer_input
+    
+    def test_output_files_top_level_dirs(self):
+        """Test that only top-level output directories are transferred."""
+        self.job.output = [
+            "output/results/data.txt",
+            "output/logs/job.log",
+            "/staging/shared-output/result.txt"
+        ]
+        
+        _, transfer_output = self.executor._get_files_for_transfer(self.job)
+        
+        # Only 'output' directory should be in transfer (staging excluded)
+        assert "output" in transfer_output
+        assert len([f for f in transfer_output if f == "output"]) == 1
+        assert "/staging/shared-output/result.txt" not in transfer_output
+    
+    def test_config_files_handling(self):
+        """Test that config files are properly handled."""
+        self.executor.workflow.configfiles = [
+            "/home/user/config.yaml",
+            "/staging/shared-config.yaml"
+        ]
+        
+        transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+        
+        # Home config should be transferred, staging config should not
+        assert "/home/user/config.yaml" in transfer_input
+        assert "/staging/shared-config.yaml" not in transfer_input
+    
+    def test_empty_job(self):
+        """Test handling of job with no inputs or outputs."""
+        transfer_input, transfer_output = self.executor._get_files_for_transfer(self.job)
+        
+        # Should only have Snakefile
+        assert len(transfer_input) == 1
+        assert transfer_output == []
+
+
+class TestPrepareConfigFilesForTransfer:
+    """Test the _prepare_config_files_for_transfer method."""
+    
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.workflow = Mock()
+        
+        # Bind the actual method to our mock
+        self.executor._prepare_config_files_for_transfer = (
+            Executor._prepare_config_files_for_transfer.__get__(self.executor, Executor)
+        )
+    
+    def test_no_config_files(self):
+        """Test when no config files are present."""
+        self.executor.workflow.configfiles = None
+        job_args = "--target-jobs test --cores 1"
+        
+        modified_args, config_names = self.executor._prepare_config_files_for_transfer(job_args)
+        
+        assert modified_args == job_args
+        assert config_names == []
+    
+    def test_single_config_file(self):
+        """Test with a single config file."""
+        self.executor.workflow.configfiles = ["/home/user/config.yaml"]
+        job_args = "--target-jobs test --configfiles /home/user/config.yaml --cores 1"
+        
+        modified_args, config_names = self.executor._prepare_config_files_for_transfer(job_args)
+        
+        assert "config.yaml" in modified_args
+        assert "/home/user/config.yaml" not in modified_args
+        assert config_names == ["config.yaml"]
+    
+    def test_multiple_config_files(self):
+        """Test with multiple config files."""
+        self.executor.workflow.configfiles = [
+            "/home/user/config1.yaml",
+            "/home/user/config2.yaml"
+        ]
+        job_args = "--target-jobs test --configfiles /home/user/config1.yaml /home/user/config2.yaml --cores 1"
+        
+        modified_args, config_names = self.executor._prepare_config_files_for_transfer(job_args)
+        
+        assert "config1.yaml" in modified_args
+        assert "config2.yaml" in modified_args
+        assert "/home/user/config1.yaml" not in modified_args
+        assert len(config_names) == 2
+
+
+class TestValidateSharedFsConfiguration:
+    """Test the _validate_shared_fs_configuration method."""
+    
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+        self.executor.shared_fs_prefixes = []
+        self.executor.workflow = Mock()
+        self.executor.workflow.storage_settings = Mock()
+        self.executor.workflow.storage_settings.shared_fs_usage = []
+        
+        # Bind the actual method to our mock
+        self.executor._validate_shared_fs_configuration = (
+            Executor._validate_shared_fs_configuration.__get__(self.executor, Executor)
+        )
+    
+    def test_no_shared_prefixes_no_validation(self):
+        """Test that validation is skipped when no prefixes are configured."""
+        self.executor.shared_fs_prefixes = []
+        
+        self.executor._validate_shared_fs_configuration()
+        
+        # Should not log anything
+        self.executor.logger.info.assert_not_called()
+    
+    def test_shared_prefixes_with_none_usage_logs_info(self):
+        """Test that info message is logged for partial shared FS configuration."""
+        self.executor.shared_fs_prefixes = ["/staging/", "/shared/"]
+        self.executor.workflow.storage_settings.shared_fs_usage = []  # empty = "none"
+        
+        self.executor._validate_shared_fs_configuration()
+        
+        # Should log informational message
+        self.executor.logger.info.assert_called_once()
+        call_args = self.executor.logger.info.call_args[0][0]
+        assert "partially shared filesystem" in call_args.lower()
+        assert "/staging/" in call_args
+        assert "/shared/" in call_args
+    
+    def test_shared_prefixes_with_some_usage_no_warning(self):
+        """Test that no warning is issued when shared_fs_usage has values."""
+        self.executor.shared_fs_prefixes = ["/staging/"]
+        self.executor.workflow.storage_settings.shared_fs_usage = ["input-output", "persistence"]
+        
+        self.executor._validate_shared_fs_configuration()
+        
+        # Should not log anything (configuration is valid but not "none")
+        # The method only logs for the "none" case currently
+        # This test ensures we don't crash with non-empty shared_fs_usage
+        assert True  # No exception raised
+
+
+class TestExecutorSettings:
+    """Test ExecutorSettings configuration."""
+    
+    def test_default_settings(self):
+        """Test default settings values."""
+        settings = ExecutorSettings()
+        
+        assert settings.jobdir == ".snakemake/htcondor"
+        assert settings.shared_fs_prefixes is None
+    
+    def test_custom_jobdir(self):
+        """Test custom jobdir setting."""
+        settings = ExecutorSettings(jobdir="/custom/path/logs")
+        
+        assert settings.jobdir == "/custom/path/logs"
+    
+    def test_custom_shared_fs_prefixes(self):
+        """Test custom shared_fs_prefixes setting."""
+        settings = ExecutorSettings(shared_fs_prefixes="/staging,/shared")
+        
+        assert settings.shared_fs_prefixes == "/staging,/shared"


### PR DESCRIPTION
This PR adds executor support for HTCondor clusters that have partially-shared filesystems between Access Points and Execution Points.

To use this feature, specify:
```
shared-fs-usage: none
htcondor-shared-fs-prefixes: <comma-separated list of shared fs prefixes>
```

For example, if the `/staging` directory is available between AP and EP but jobs are submitted from a user's home directory, you'd configure:
```
shared-fs-usage: none
htcondor-shared-fs-prefixes: "/staging"
```
The result of this would be that any workflow inputs/outputs existing under `/staging` are not transferred but accessed using their absolute path, while any other files (Snakefile, config files, input/output) not under the path are handed to HTCondor for CEDAR transfers.

There's some tension in that this config mechanism has users provide two flags that seem to contradict one another -- there's no shared filesystem, but some path prefixes represent are shared.

Why did I do this? My understanding of the Snakemake data model with respect to shared filesystems is that you can label which _categories_ of files exist in the shared filesystem but not actual path prefixes. For example, I might specify `--shared-fs-usage input-output` to tell Snakemake that all inputs/outputs live on the shared filesystem.

Unfortunately, in an HTCondor cluster, it's perfectly reasonable that inputs and outputs are split between shared and non-shared paths. Snakemake doesn't appear to have a built-in way to reason over path-based splits, only category-based splits. This is where the tension comes from. I may revisit this concept in the future.