### PR TITLE
Be more careful about path handling for Snakefiles, job wrappers, etc.

### DIFF
--- a/tests/test_job_wrapper.py
+++ b/tests/test_job_wrapper.py
@@ -1,0 +1,292 @@
+"""
+Unit tests for job wrapper and job argument handling in HTCondor executor.
+
+These tests verify that:
+1. Job wrapper scripts in subdirectories preserve their relative paths
+2. Job arguments are correctly extracted and sanitized
+3. The executable/arguments split works correctly with and without wrappers
+
+BACKGROUND - Issue #8:
+======================
+A user reported that they couldn't use a job wrapper nested in a subdirectory
+(e.g., workflow/wrapper.sh) when using the HTCondor executor. The bug was that
+basename() was being used on the wrapper path, stripping the directory.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+from snakemake_executor_plugin_htcondor import Executor
+
+
+class TestGetJobExecAndArgs:
+    """Test the _get_job_exec_and_args helper method."""
+
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+
+        # Bind the actual methods to our mock
+        self.executor._get_job_exec_and_args = Executor._get_job_exec_and_args.__get__(
+            self.executor, Executor
+        )
+        self.executor._sanitize_job_args = Executor._sanitize_job_args.__get__(
+            self.executor, Executor
+        )
+
+        # Default mock for format_job_exec
+        self.executor.format_job_exec = Mock(
+            return_value="python -m snakemake --snakefile Snakefile --cores 1"
+        )
+        self.executor.get_python_executable = Mock(return_value="python")
+
+    def test_wrapper_in_subdirectory_preserves_path(self):
+        """
+        Test that wrapper in subdirectory preserves the full relative path.
+
+        This is the critical test for issue #8. The wrapper path must NOT
+        be stripped to basename.
+        """
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(return_value="workflow/wrapper.sh")
+
+        job_exec, job_args = self.executor._get_job_exec_and_args(job)
+
+        # The executable MUST be the full relative path
+        assert job_exec == "workflow/wrapper.sh"
+        # Should NOT be just the basename
+        assert job_exec != "wrapper.sh"
+
+    def test_wrapper_deeply_nested_preserves_path(self):
+        """Test deeply nested wrapper path is preserved."""
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(
+            return_value="workflow/scripts/wrappers/htcondor_wrapper.sh"
+        )
+
+        job_exec, job_args = self.executor._get_job_exec_and_args(job)
+
+        assert job_exec == "workflow/scripts/wrappers/htcondor_wrapper.sh"
+
+    def test_wrapper_at_root_level(self):
+        """Test wrapper at root level works correctly."""
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(return_value="wrapper.sh")
+
+        job_exec, job_args = self.executor._get_job_exec_and_args(job)
+
+        assert job_exec == "wrapper.sh"
+
+    def test_no_wrapper_uses_python_executable(self):
+        """Test that when no wrapper is specified, Python is used as executable."""
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(return_value=None)  # No wrapper
+
+        job_exec, job_args = self.executor._get_job_exec_and_args(job)
+
+        assert job_exec == "python"
+        self.executor.get_python_executable.assert_called_once()
+
+    def test_wrapper_strips_snakemake_prefix_from_args(self):
+        """Test that with wrapper, 'python -m snakemake ' prefix is stripped."""
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(return_value="wrapper.sh")
+        self.executor.format_job_exec = Mock(
+            return_value="python -m snakemake --snakefile Snakefile --cores 1 --target all"
+        )
+
+        job_exec, job_args = self.executor._get_job_exec_and_args(job)
+
+        assert job_args == "--snakefile Snakefile --cores 1 --target all"
+        assert "python -m snakemake" not in job_args
+
+    def test_no_wrapper_strips_python_prefix_from_args(self):
+        """Test that without wrapper, python executable prefix is stripped."""
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(return_value=None)
+        self.executor.get_python_executable = Mock(return_value="/usr/bin/python3")
+        self.executor.format_job_exec = Mock(
+            return_value="/usr/bin/python3 -m snakemake --snakefile Snakefile"
+        )
+
+        job_exec, job_args = self.executor._get_job_exec_and_args(job)
+
+        assert job_exec == "/usr/bin/python3"
+        assert job_args == "-m snakemake --snakefile Snakefile"
+
+
+class TestSanitizeJobArgs:
+    """Test the _sanitize_job_args helper method."""
+
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+
+        # Bind the actual method to our mock
+        self.executor._sanitize_job_args = Executor._sanitize_job_args.__get__(
+            self.executor, Executor
+        )
+
+    def test_removes_single_quotes(self):
+        """Test that single quotes are removed from arguments."""
+        job_args = "--config key='value' --other 'quoted'"
+
+        result = self.executor._sanitize_job_args(job_args)
+
+        assert "'" not in result
+        assert result == "--config key=value --other quoted"
+
+    def test_no_warning_when_no_quotes(self):
+        """Test that no warning is logged when there are no single quotes."""
+        job_args = "--config key=value --other arg"
+
+        result = self.executor._sanitize_job_args(job_args)
+
+        assert result == job_args
+        self.executor.logger.warning.assert_not_called()
+
+    def test_preserves_double_quotes(self):
+        """Test that double quotes are preserved (only single quotes removed)."""
+        job_args = '--config key="value" --other "quoted"'
+
+        result = self.executor._sanitize_job_args(job_args)
+
+        assert result == job_args
+        assert '"' in result
+
+    def test_empty_string(self):
+        """Test handling of empty string."""
+        result = self.executor._sanitize_job_args("")
+
+        assert result == ""
+        self.executor.logger.warning.assert_not_called()
+
+
+class TestJobWrapperIntegration:
+    """
+    Integration tests that verify the complete flow of job wrapper handling.
+
+    These tests use more realistic mock setups to verify the interaction
+    between _get_job_exec_and_args and the rest of the executor.
+    """
+
+    def setup_method(self):
+        """Setup mock executor with more complete configuration."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+
+        # Bind actual methods
+        self.executor._get_job_exec_and_args = Executor._get_job_exec_and_args.__get__(
+            self.executor, Executor
+        )
+        self.executor._sanitize_job_args = Executor._sanitize_job_args.__get__(
+            self.executor, Executor
+        )
+
+    def test_wrapper_with_snakefile_in_same_directory(self):
+        """
+        Test scenario from issue #8: wrapper and Snakefile in workflow/ directory.
+
+        User has:
+        - workflow/Snakefile
+        - workflow/wrapper.sh
+
+        The wrapper must be 'workflow/wrapper.sh', not 'wrapper.sh'.
+        """
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(return_value="workflow/wrapper.sh")
+        self.executor.format_job_exec = Mock(
+            return_value="python -m snakemake --snakefile workflow/Snakefile --cores 1"
+        )
+
+        job_exec, job_args = self.executor._get_job_exec_and_args(job)
+
+        # Critical: wrapper path must be preserved
+        assert job_exec == "workflow/wrapper.sh"
+        # Args should have snakefile path
+        assert "--snakefile workflow/Snakefile" in job_args
+
+    def test_args_are_sanitized_automatically(self):
+        """Test that _get_job_exec_and_args returns sanitized arguments."""
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(return_value="workflow/wrapper.sh")
+        self.executor.format_job_exec = Mock(
+            return_value="python -m snakemake --config name='test' --cores 1"
+        )
+
+        # Get executable and args - args should already be sanitized
+        job_exec, job_args = self.executor._get_job_exec_and_args(job)
+
+        assert job_exec == "workflow/wrapper.sh"
+        # Single quotes should already be removed
+        assert "'" not in job_args
+        assert "--config name=test" in job_args
+
+
+class TestJobWrapperEdgeCases:
+    """Test edge cases for job wrapper handling."""
+
+    def setup_method(self):
+        """Setup mock executor."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+        self.executor._get_job_exec_and_args = Executor._get_job_exec_and_args.__get__(
+            self.executor, Executor
+        )
+        self.executor._sanitize_job_args = Executor._sanitize_job_args.__get__(
+            self.executor, Executor
+        )
+        self.executor.get_python_executable = Mock(return_value="python")
+        self.executor.format_job_exec = Mock(
+            return_value="python -m snakemake --cores 1"
+        )
+
+    def test_wrapper_with_spaces_in_path(self):
+        """Test wrapper path with spaces (edge case)."""
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(return_value="my workflow/wrapper script.sh")
+
+        job_exec, _ = self.executor._get_job_exec_and_args(job)
+
+        assert job_exec == "my workflow/wrapper script.sh"
+
+    def test_wrapper_with_dots_in_path(self):
+        """Test wrapper path with dots (e.g., hidden directories)."""
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(return_value=".hidden/scripts/wrapper.sh")
+
+        job_exec, _ = self.executor._get_job_exec_and_args(job)
+
+        assert job_exec == ".hidden/scripts/wrapper.sh"
+
+    def test_wrapper_absolute_path(self):
+        """Test that absolute wrapper paths are preserved."""
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(return_value="/home/user/workflow/wrapper.sh")
+
+        job_exec, _ = self.executor._get_job_exec_and_args(job)
+
+        assert job_exec == "/home/user/workflow/wrapper.sh"
+
+    def test_wrapper_empty_string_treated_as_no_wrapper(self):
+        """Test that empty string wrapper falls back to Python."""
+        job = Mock()
+        job.resources = Mock()
+        job.resources.get = Mock(return_value="")  # Empty string is falsy
+
+        job_exec, _ = self.executor._get_job_exec_and_args(job)
+
+        # Empty string is falsy, so should use Python
+        assert job_exec == "python"

--- a/tests/test_job_wrapper.py
+++ b/tests/test_job_wrapper.py
@@ -13,8 +13,8 @@ A user reported that they couldn't use a job wrapper nested in a subdirectory
 basename() was being used on the wrapper path, stripping the directory.
 """
 
-import pytest
-from unittest.mock import Mock, patch
+
+from unittest.mock import Mock
 from snakemake_executor_plugin_htcondor import Executor
 
 

--- a/tests/test_shared_fs.py
+++ b/tests/test_shared_fs.py
@@ -10,113 +10,115 @@ from snakemake_executor_plugin_htcondor import is_shared_fs, ExecutorSettings, E
 
 class TestIsSharedFs:
     """Test the is_shared_fs helper function."""
-    
+
     def test_path_on_shared_fs(self):
         """Test that paths under shared prefixes are correctly identified."""
         # One with trailing /, the other without
         shared_prefixes = ["/staging/", "/shared"]
-        
+
         assert is_shared_fs("/staging/user/data.txt", shared_prefixes) is True
         assert is_shared_fs("/shared/project/file.txt", shared_prefixes) is True
-    
+
     def test_path_not_on_shared_fs(self):
         """Test that paths not under shared prefixes are correctly identified."""
         shared_prefixes = ["/staging/", "/shared"]
-        
+
         assert is_shared_fs("/home/user/data.txt", shared_prefixes) is False
         assert is_shared_fs("input/local-file.txt", shared_prefixes) is False
-    
+
     def test_empty_shared_prefixes(self):
         """Test that no paths match when shared_prefixes is empty."""
         shared_prefixes = []
-        
+
         assert is_shared_fs("/staging/user/data.txt", shared_prefixes) is False
         assert is_shared_fs("/any/path/file.txt", shared_prefixes) is False
-    
+
     def test_normalized_paths(self):
         """Test that paths are normalized correctly for comparison."""
         shared_prefixes = ["/staging"]
-        
+
         # Should work even if prefix doesn't end with /
         assert is_shared_fs("/staging/user/data.txt", ["/staging"]) is True
-        
+
         # Should normalize path with trailing separator
         assert is_shared_fs("/staging/", shared_prefixes) is True
-    
+
     def test_partial_match_rejected(self):
         """Test that partial prefix matches are rejected."""
         shared_prefixes = ["/staging"]
-        
+
         # /staging2/ should not match /staging/
         assert is_shared_fs("/staging2/user/data.txt", shared_prefixes) is False
 
 
 class TestParseSharedFsPrefixes:
     """Test the _parse_shared_fs_prefixes method."""
-    
+
     def setup_method(self):
         """Setup mock executor for testing."""
         self.executor = Mock(spec=Executor)
         self.executor.logger = Mock()
-        
+
         # Bind the actual method to our mock
-        self.executor._parse_shared_fs_prefixes = Executor._parse_shared_fs_prefixes.__get__(
-            self.executor, Executor
+        self.executor._parse_shared_fs_prefixes = (
+            Executor._parse_shared_fs_prefixes.__get__(self.executor, Executor)
         )
-    
+
     def test_parse_single_prefix(self):
         """Test parsing a single filesystem prefix."""
         result = self.executor._parse_shared_fs_prefixes("/staging")
-        
+
         assert len(result) == 1
         assert result[0] == "/staging/"
-    
+
     def test_parse_multiple_prefixes(self):
         """Test parsing comma-separated prefixes."""
         result = self.executor._parse_shared_fs_prefixes("/staging/,/shared,/data")
-        
+
         assert len(result) == 3
         assert "/staging/" in result
         assert "/shared/" in result
         assert "/data/" in result
-    
+
     def test_parse_with_whitespace(self):
         """Test parsing handles whitespace correctly."""
-        result = self.executor._parse_shared_fs_prefixes(" /staging/ , /shared , /data ")
-        
+        result = self.executor._parse_shared_fs_prefixes(
+            " /staging/ , /shared , /data "
+        )
+
         assert len(result) == 3
         assert all(prefix.strip() == prefix for prefix in result)
-    
+
     def test_parse_with_quotes(self):
         """Test parsing removes quotes from prefixes."""
         result = self.executor._parse_shared_fs_prefixes("'/staging/',\"/shared\"")
-        
+
         assert len(result) == 2
         assert result[0] == "/staging/"
         assert result[1] == "/shared/"
-    
+
     def test_parse_none_returns_empty_list(self):
         """Test that None input returns empty list."""
         result = self.executor._parse_shared_fs_prefixes(None)
-        
+
         assert result == []
-    
+
     def test_parse_empty_string_returns_empty_list(self):
         """Test that empty string returns empty list."""
         result = self.executor._parse_shared_fs_prefixes("")
-        
+
         assert result == []
-    
+
     def test_parse_only_whitespace_returns_empty_list(self):
         """Test that whitespace-only string returns empty list."""
         result = self.executor._parse_shared_fs_prefixes("   ,  , ")
-        
+
         assert result == []
 
 
 class TestGetFilesForTransfer:
     """Test the _get_files_for_transfer method."""
-    
+
     def setup_method(self):
         """Setup mock executor and job for testing."""
         self.executor = Mock(spec=Executor)
@@ -125,82 +127,113 @@ class TestGetFilesForTransfer:
         self.executor.workflow = Mock()
         self.executor.workflow.configfiles = []
         self.executor.get_snakefile = Mock(return_value="/home/user/Snakefile")
-        
+
         # Bind the actual method to our mock
-        self.executor._get_files_for_transfer = Executor._get_files_for_transfer.__get__(
-            self.executor, Executor
+        self.executor._get_files_for_transfer = (
+            Executor._get_files_for_transfer.__get__(self.executor, Executor)
         )
-        
+
         # Create mock job
         self.job = Mock()
         self.job.input = []
         self.job.output = []
         self.job.resources = Mock()
-        self.job.resources.get = Mock(return_value=True)  # Default preserve_relative_paths=True
-    
+        self.job.resources.get = Mock(
+            return_value=True
+        )  # Default preserve_relative_paths=True
+
     def test_snakefile_not_on_shared_fs(self):
         """Test that Snakefile not on shared FS is included in transfer."""
         transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-        
+
         assert "/home/user/Snakefile" in transfer_input
-    
+
     def test_snakefile_on_shared_fs(self):
         """Test that Snakefile on shared FS is excluded from transfer."""
         self.executor.get_snakefile = Mock(return_value="/staging/user/Snakefile")
-        
+
         transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-        
+
         assert "/staging/user/Snakefile" not in transfer_input
-    
+
+    def test_snakefile_relative_path_preserved(self):
+        """Test that relative Snakefile paths in subdirectories are preserved.
+
+        This is a regression test for GitHub issue #8 - Snakefiles in
+        subdirectories (e.g., workflow/Snakefile) must preserve their
+        full relative path when added to transfer_input_files.
+        """
+        # Use a relative path in a subdirectory
+        self.executor.get_snakefile = Mock(return_value="workflow/Snakefile")
+
+        transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+
+        # Full relative path must be preserved, not just basename
+        assert "workflow/Snakefile" in transfer_input
+        # Ensure basename alone is NOT in the list (would be wrong)
+        assert transfer_input.count("Snakefile") == 0  # No bare "Snakefile"
+
+    def test_snakefile_nested_subdirectory_preserved(self):
+        """Test that deeply nested Snakefile paths are preserved."""
+        self.executor.get_snakefile = Mock(
+            return_value="project/workflow/rules/Snakefile"
+        )
+
+        transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+
+        assert "project/workflow/rules/Snakefile" in transfer_input
+
     def test_input_files_mixed_locations(self):
         """Test handling of input files in mixed locations."""
         self.job.input = [
             "input/local-file.txt",
             "/staging/user/shared-file.txt",
-            "/home/user/another-file.txt"
+            "/home/user/another-file.txt",
         ]
-        
+
         transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-        
+
         # Local and home files should be transferred
         assert "input/local-file.txt" in transfer_input
         assert "/home/user/another-file.txt" in transfer_input
-        
+
         # Staging file should not be transferred
         assert "/staging/user/shared-file.txt" not in transfer_input
-    
+
     def test_output_files_top_level_dirs(self):
         """Test that only top-level output directories are transferred."""
         self.job.output = [
             "output/results/data.txt",
             "output/logs/job.log",
-            "/staging/shared-output/result.txt"
+            "/staging/shared-output/result.txt",
         ]
-        
+
         _, transfer_output = self.executor._get_files_for_transfer(self.job)
-        
+
         # Only 'output' directory should be in transfer (staging excluded)
         assert "output" in transfer_output
         assert len([f for f in transfer_output if f == "output"]) == 1
         assert "/staging/shared-output/result.txt" not in transfer_output
-    
+
     def test_config_files_handling(self):
         """Test that config files are properly handled."""
         self.executor.workflow.configfiles = [
             "/home/user/config.yaml",
-            "/staging/shared-config.yaml"
+            "/staging/shared-config.yaml",
         ]
-        
+
         transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-        
+
         # Home config should be transferred, staging config should not
         assert "/home/user/config.yaml" in transfer_input
         assert "/staging/shared-config.yaml" not in transfer_input
-    
+
     def test_empty_job(self):
         """Test handling of job with no inputs or outputs."""
-        transfer_input, transfer_output = self.executor._get_files_for_transfer(self.job)
-        
+        transfer_input, transfer_output = self.executor._get_files_for_transfer(
+            self.job
+        )
+
         # Should only have Snakefile
         assert len(transfer_input) == 1
         assert transfer_output == []
@@ -208,48 +241,54 @@ class TestGetFilesForTransfer:
 
 class TestPrepareConfigFilesForTransfer:
     """Test the _prepare_config_files_for_transfer method."""
-    
+
     def setup_method(self):
         """Setup mock executor for testing."""
         self.executor = Mock(spec=Executor)
         self.executor.workflow = Mock()
-        
+
         # Bind the actual method to our mock
         self.executor._prepare_config_files_for_transfer = (
             Executor._prepare_config_files_for_transfer.__get__(self.executor, Executor)
         )
-    
+
     def test_no_config_files(self):
         """Test when no config files are present."""
         self.executor.workflow.configfiles = None
         job_args = "--target-jobs test --cores 1"
-        
-        modified_args, config_names = self.executor._prepare_config_files_for_transfer(job_args)
-        
+
+        modified_args, config_names = self.executor._prepare_config_files_for_transfer(
+            job_args
+        )
+
         assert modified_args == job_args
         assert config_names == []
-    
+
     def test_single_config_file(self):
         """Test with a single config file."""
         self.executor.workflow.configfiles = ["/home/user/config.yaml"]
         job_args = "--target-jobs test --configfiles /home/user/config.yaml --cores 1"
-        
-        modified_args, config_names = self.executor._prepare_config_files_for_transfer(job_args)
-        
+
+        modified_args, config_names = self.executor._prepare_config_files_for_transfer(
+            job_args
+        )
+
         assert "config.yaml" in modified_args
         assert "/home/user/config.yaml" not in modified_args
         assert config_names == ["config.yaml"]
-    
+
     def test_multiple_config_files(self):
         """Test with multiple config files."""
         self.executor.workflow.configfiles = [
             "/home/user/config1.yaml",
-            "/home/user/config2.yaml"
+            "/home/user/config2.yaml",
         ]
         job_args = "--target-jobs test --configfiles /home/user/config1.yaml /home/user/config2.yaml --cores 1"
-        
-        modified_args, config_names = self.executor._prepare_config_files_for_transfer(job_args)
-        
+
+        modified_args, config_names = self.executor._prepare_config_files_for_transfer(
+            job_args
+        )
+
         assert "config1.yaml" in modified_args
         assert "config2.yaml" in modified_args
         assert "/home/user/config1.yaml" not in modified_args
@@ -258,7 +297,7 @@ class TestPrepareConfigFilesForTransfer:
 
 class TestValidateSharedFsConfiguration:
     """Test the _validate_shared_fs_configuration method."""
-    
+
     def setup_method(self):
         """Setup mock executor for testing."""
         self.executor = Mock(spec=Executor)
@@ -267,42 +306,45 @@ class TestValidateSharedFsConfiguration:
         self.executor.workflow = Mock()
         self.executor.workflow.storage_settings = Mock()
         self.executor.workflow.storage_settings.shared_fs_usage = []
-        
+
         # Bind the actual method to our mock
         self.executor._validate_shared_fs_configuration = (
             Executor._validate_shared_fs_configuration.__get__(self.executor, Executor)
         )
-    
+
     def test_no_shared_prefixes_no_validation(self):
         """Test that validation is skipped when no prefixes are configured."""
         self.executor.shared_fs_prefixes = []
-        
+
         self.executor._validate_shared_fs_configuration()
-        
+
         # Should not log anything
         self.executor.logger.info.assert_not_called()
-    
+
     def test_shared_prefixes_with_none_usage_logs_info(self):
         """Test that info message is logged for partial shared FS configuration."""
         self.executor.shared_fs_prefixes = ["/staging/", "/shared/"]
         self.executor.workflow.storage_settings.shared_fs_usage = []  # empty = "none"
-        
+
         self.executor._validate_shared_fs_configuration()
-        
+
         # Should log informational message
         self.executor.logger.info.assert_called_once()
         call_args = self.executor.logger.info.call_args[0][0]
         assert "partially shared filesystem" in call_args.lower()
         assert "/staging/" in call_args
         assert "/shared/" in call_args
-    
+
     def test_shared_prefixes_with_some_usage_no_warning(self):
         """Test that no warning is issued when shared_fs_usage has values."""
         self.executor.shared_fs_prefixes = ["/staging/"]
-        self.executor.workflow.storage_settings.shared_fs_usage = ["input-output", "persistence"]
-        
+        self.executor.workflow.storage_settings.shared_fs_usage = [
+            "input-output",
+            "persistence",
+        ]
+
         self.executor._validate_shared_fs_configuration()
-        
+
         # Should not log anything (configuration is valid but not "none")
         # The method only logs for the "none" case currently
         # This test ensures we don't crash with non-empty shared_fs_usage
@@ -311,22 +353,22 @@ class TestValidateSharedFsConfiguration:
 
 class TestExecutorSettings:
     """Test ExecutorSettings configuration."""
-    
+
     def test_default_settings(self):
         """Test default settings values."""
         settings = ExecutorSettings()
-        
+
         assert settings.jobdir == ".snakemake/htcondor"
         assert settings.shared_fs_prefixes is None
-    
+
     def test_custom_jobdir(self):
         """Test custom jobdir setting."""
         settings = ExecutorSettings(jobdir="/custom/path/logs")
-        
+
         assert settings.jobdir == "/custom/path/logs"
-    
+
     def test_custom_shared_fs_prefixes(self):
         """Test custom shared_fs_prefixes setting."""
         settings = ExecutorSettings(shared_fs_prefixes="/staging,/shared")
-        
+
         assert settings.shared_fs_prefixes == "/staging,/shared"


### PR DESCRIPTION
There was a bug in calling `basename()` on HTCondor executable job wrappers because using something like `workflow/wrapper.sh` would get flattened to `wrapper.sh` and added as the `executable` argument for HTCondor's CEDAR transfer mechanism. Because the path doesn't exist, HTCondor can't transfer the file.

This commit fixes the bug, but also pulls some of the other stuff into separate helper functions so that they're easier to mock/test.

A lot of the noise comes from running `black` on the files I touched. I should have done this in a separate commit, but it's too late now!

Closes #7
Closes #8
Closes #9