### PR TITLE
Improve input/output file handling

### DIFF
--- a/docs/further.md
+++ b/docs/further.md
@@ -10,15 +10,17 @@
 
 
 The following [submit description file commands](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html) are supported (add them as user-defined resources):
-| Basic             | Matchmaking      | Matchmaking (GPU)         | Policy                     |
-| ----------------- | ---------------- | ------------------------- | -------------------------- |
-| `getenv`          | `rank`           | `request_gpus`            | `max_retries`              |
-| `environment`     | `request_disk`   | `require_gpus`            | `allowed_execute_duration` |
-| `input`           | `request_memory` | `gpus_minimum_capability` | `allowed_job_duration`     |
-| `max_materialize` | `requirements`   | `gpus_minimum_memory`     | `retry_until`              |
-| `max_idle`        | `classad_<foo>`**| `gpus_minimum_runtime`    |                            |
-| `job_wrapper`*    |                  | `cuda_version`            |                            |
-| `universe`        |                  |                           |                            |
+| Basic                              | Matchmaking      | Matchmaking (GPU)         | Policy                     |
+| ---------------------------------- | ---------------- | ------------------------- | -------------------------- |
+| `getenv`                           | `rank`           | `request_gpus`            | `max_retries`              |
+| `environment`                      | `request_disk`   | `require_gpus`            | `allowed_execute_duration` |
+| `input`                            | `request_memory` | `gpus_minimum_capability` | `allowed_job_duration`     |
+| `max_materialize`                  | `requirements`   | `gpus_minimum_memory`     | `retry_until`              |
+| `max_idle`                         | `classad_<foo>`**| `gpus_minimum_runtime`    |                            |
+| `job_wrapper`*                     |                  | `cuda_version`            |                            |
+| `universe`                         |                  |                           |                            |
+| `htcondor_transfer_input_files`*** |                  |                           |                            |
+| `htcondor_transfer_output_files`***|                  |                           |                            |
 
 
 \* A custom-defined `job_wrapper` resource will be used as the HTCondor executable for the job. It can be used for environment setup, but must pass all arguments
@@ -39,6 +41,22 @@ snakemake "$@"
 
 \*\* Custom ClassAds can be defined using the `classad_` prefix as a custom job resource. For example, to define the ClassAd `+MyClassAd`, define `classad_MyClassAd` in
 the job's resources.
+
+\*\*\* Additional input or output files for transfer can be specified using `htcondor_transfer_input_files` and `htcondor_transfer_output_files` resources.
+These are useful for transferring files that aren't part of the rule's `input:`/`output:` directives (e.g., helper scripts, configuration files, logs, intermediate results).
+Supports both string (comma-separated) and list formats, and wildcards will be expanded.
+Files on shared filesystem prefixes are automatically excluded from transfer.
+
+Example usage:
+```python
+rule process:
+    input: "data/{sample}.txt"
+    output: "results/{sample}.out"
+    resources:
+        htcondor_transfer_input_files="scripts/helpers.py,config/params.yaml",
+        htcondor_transfer_output_files="logs/{sample}.log"
+    script: "scripts/process.py"
+```
 
 ## Jobs Without Shared Filesystems
 

--- a/docs/further.md
+++ b/docs/further.md
@@ -44,7 +44,7 @@ the job's resources.
 
 \*\*\* Additional input or output files for transfer can be specified using `htcondor_transfer_input_files` and `htcondor_transfer_output_files` resources.
 These are useful for transferring files that aren't part of the rule's `input:`/`output:` directives (e.g., helper scripts, configuration files, logs, intermediate results).
-Supports both string (comma-separated) and list formats, and wildcards will be expanded.
+Supports both string (comma-separated) and list formats. Wildcards (e.g., `{sample}`) are expanded for individual jobs, but **not** for grouped jobs since the resources are defined at the group level.
 Files on shared filesystem prefixes are automatically excluded from transfer.
 
 Example usage:

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -13,11 +13,10 @@ from snakemake_interface_common.exceptions import WorkflowError  # noqa
 
 import htcondor2 as htcondor
 import traceback
-from os.path import join, isabs, relpath, basename, abspath, normpath, exists
+from os.path import join, isabs, relpath, normpath, exists
 from os import makedirs, sep
 import re
 import sys
-import logging
 
 
 def is_shared_fs(in_path, shared_prefixes) -> bool:
@@ -171,7 +170,7 @@ class Executor(RemoteExecutor):
         """
         # Explicitly handle empty/None filepaths
         if file_path is None or str(file_path).strip() == "":
-            self.logger.debug(f"Skipping empty or None filepath")
+            self.logger.debug("Skipping empty or None filepath")
             return
 
         file_path = str(file_path).strip()
@@ -470,7 +469,13 @@ class Executor(RemoteExecutor):
                     job_args = full_cmd.removeprefix(prefix)
                     break
             else:
-                # Fallback: just remove up to "-m"
+                # Fallback: no known prefix matched
+                # This is unexpected and might indicate a problem with command formatting
+                self.logger.warning(
+                    f"Could not strip Python executable prefix from command: '{full_cmd}'. "
+                    f"Expected to start with one of: {sys.executable}, python, or {self.get_python_executable()}. "
+                    f"Falling back to naive space-based splitting."
+                )
                 job_args = full_cmd.split(" ", 1)[1] if " " in full_cmd else full_cmd
 
         # Sanitize arguments before returning

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -101,6 +101,10 @@ class Executor(RemoteExecutor):
         # jobDir: Directory where the job will tore log, output and error files.
         self.jobDir = self.workflow.executor_settings.jobdir
 
+        # Create the job directory immediately so it exists even if no jobs are submitted
+        # This ensures logs/errors can be checked in CI/CD regardless of workflow success
+        makedirs(self.jobDir, exist_ok=True)
+
         # Parse shared filesystem prefixes
         self.shared_fs_prefixes = self._parse_shared_fs_prefixes(
             self.workflow.executor_settings.shared_fs_prefixes
@@ -573,9 +577,6 @@ class Executor(RemoteExecutor):
 
     def run_job(self, job: JobExecutorInterface):
         # Submitting job to HTCondor
-
-        # Creating directory to store log, output and error files
-        makedirs(self.jobDir, exist_ok=True)
 
         # Determine if file transfer is needed based on shared filesystem configuration
         # When shared_fs_usage is set (truthy), AP and EP share a filesystem

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,153 @@
+"""
+Shared test fixtures and utilities for HTCondor executor tests.
+"""
+
+from unittest.mock import Mock
+from snakemake_executor_plugin_htcondor import Executor
+
+
+def create_mock_executor(shared_fs_prefixes=None):
+    """
+    Create a mock executor with common setup.
+
+    Args:
+        shared_fs_prefixes: List of shared filesystem prefixes. Defaults to empty list.
+
+    Returns:
+        Mock executor with bound methods.
+    """
+    executor = Mock(spec=Executor)
+    executor.logger = Mock()
+    executor.shared_fs_prefixes = shared_fs_prefixes or []
+    executor.workflow = Mock()
+    executor.workflow.configfiles = []
+    executor.get_snakefile = Mock(return_value="Snakefile")
+
+    # Bind the actual methods to the mock
+    executor._get_files_for_transfer = Executor._get_files_for_transfer.__get__(
+        executor, Executor
+    )
+    executor._add_file_if_transferable = Executor._add_file_if_transferable.__get__(
+        executor, Executor
+    )
+    executor._parse_file_list = Executor._parse_file_list.__get__(executor, Executor)
+
+    return executor
+
+
+def create_mock_individual_job(
+    script=None,
+    notebook=None,
+    input_files=None,
+    output_files=None,
+    htcondor_transfer_input_files=None,
+    htcondor_transfer_output_files=None,
+    job_wrapper=None,
+    wildcards=None,
+    params=None,
+):
+    """
+    Create a mock individual (non-grouped) job with common setup.
+
+    Args:
+        script: Path to script file or None
+        notebook: Path to notebook file or None
+        input_files: List of input files
+        output_files: List of output files
+        htcondor_transfer_input_files: Additional input files from resource
+        htcondor_transfer_output_files: Additional output files from resource
+        job_wrapper: Path to job wrapper script or None
+        wildcards: Dict of wildcards for the job
+        params: Dict of params for the job
+
+    Returns:
+        Mock job configured as individual job.
+    """
+    job = Mock()
+    job.is_group = Mock(return_value=False)
+    job.input = input_files or []
+    job.output = output_files or []
+    job.wildcards = wildcards or {}
+    job.params = params or {}
+
+    # Setup rule with script/notebook
+    job.rule = Mock()
+    job.rule.script = script
+    job.rule.notebook = notebook
+
+    # Setup resources
+    def resource_get(key, default=None):
+        resource_map = {
+            "htcondor_transfer_input_files": htcondor_transfer_input_files,
+            "htcondor_transfer_output_files": htcondor_transfer_output_files,
+            "job_wrapper": job_wrapper,
+            "preserve_relative_paths": True,
+        }
+        return resource_map.get(key, default)
+
+    job.resources = Mock()
+    job.resources.get = Mock(side_effect=resource_get)
+
+    # Setup wildcard formatting
+    def format_wildcards_func(string, **variables):
+        result = string
+        # Merge provided wildcards/params with any defaults
+        all_vars = {}
+        if "wildcards" in variables:
+            all_vars.update(variables["wildcards"])
+        if "params" in variables:
+            all_vars.update(variables["params"])
+
+        for key, value in all_vars.items():
+            result = result.replace(f"{{wildcards.{key}}}", str(value))
+            result = result.replace(f"{{params.{key}}}", str(value))
+            result = result.replace(f"{{{key}}}", str(value))
+        return result
+
+    job.format_wildcards = Mock(side_effect=format_wildcards_func)
+
+    return job
+
+
+def create_mock_group_job(
+    individual_jobs,
+    htcondor_transfer_input_files=None,
+    htcondor_transfer_output_files=None,
+):
+    """
+    Create a mock grouped job containing multiple individual jobs.
+
+    Args:
+        individual_jobs: List of mock individual jobs to include in the group
+        htcondor_transfer_input_files: Additional input files from resource
+        htcondor_transfer_output_files: Additional output files from resource
+
+    Returns:
+        Mock job configured as a group job.
+    """
+    # Use spec_set to limit what attributes the mock has
+    job = Mock(spec=["is_group", "jobs", "input", "output", "resources", "name"])
+    job.is_group = Mock(return_value=True)
+    job.jobs = individual_jobs
+    job.name = "test_group_job"
+
+    # Combine input/output from all jobs
+    job.input = []
+    job.output = []
+    for individual_job in individual_jobs:
+        job.input.extend(individual_job.input)
+        job.output.extend(individual_job.output)
+
+    # Setup resources
+    def resource_get(key, default=None):
+        resource_map = {
+            "htcondor_transfer_input_files": htcondor_transfer_input_files,
+            "htcondor_transfer_output_files": htcondor_transfer_output_files,
+            "preserve_relative_paths": True,
+        }
+        return resource_map.get(key, default)
+
+    job.resources = Mock()
+    job.resources.get = Mock(side_effect=resource_get)
+
+    return job

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ def create_mock_individual_job(
     """
     job = Mock()
     job.is_group = Mock(return_value=False)
+    job.name = "test_individual_job"
     job.input = input_files or []
     job.output = output_files or []
     job.wildcards = wildcards or {}

--- a/tests/test_config_file_paths.py
+++ b/tests/test_config_file_paths.py
@@ -12,6 +12,7 @@ shared filesystem prefixes and config file locations.
 
 from unittest.mock import Mock, MagicMock
 from snakemake_executor_plugin_htcondor import Executor
+import sys
 
 
 class TestPrepareConfigFilesForTransfer:
@@ -514,7 +515,7 @@ class TestFilesystemModes:
             "-m snakemake --configfiles /home/user/project/config.yaml --cores 1"
             in job_args
         )
-        assert job_exec == "python"
+        assert job_exec == sys.executable
 
         # No files should be transferred
         assert transfer_in == []

--- a/tests/test_config_file_paths.py
+++ b/tests/test_config_file_paths.py
@@ -466,11 +466,14 @@ class TestFilesystemModes:
 
         # Create mock job
         self.job = Mock()
+        self.job.is_group = Mock(return_value=False)
         self.job.input = []
         self.job.output = []
         self.job.threads = 1
         self.job.resources = Mock()
         self.job.resources.get = Mock(return_value=None)
+        # Mock job.rules() to return an empty list (no script/notebook in these tests)
+        self.job.rules = []
 
         # Setup job_exec_prefix mock - returns the snakemake command
         self.executor.format_job_exec = Mock(

--- a/tests/test_config_file_paths.py
+++ b/tests/test_config_file_paths.py
@@ -472,8 +472,6 @@ class TestFilesystemModes:
         self.job.threads = 1
         self.job.resources = Mock()
         self.job.resources.get = Mock(return_value=None)
-        # Mock job.rules() to return an empty list (no script/notebook in these tests)
-        self.job.rules = []
 
         # Setup job_exec_prefix mock - returns the snakemake command
         self.executor.format_job_exec = Mock(

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -258,8 +258,6 @@ class TestScriptTransfer:
         self.job.rule = Mock()
         self.job.rule.script = None
         self.job.rule.notebook = None
-        # Mock job.rules() to return an iterable containing the rule
-        self.job.rules = [self.job.rule]
 
     def test_script_file_transferred(self):
         """Test that script files are included in transfer list."""
@@ -355,8 +353,6 @@ class TestNotebookTransfer:
         self.job.rule = Mock()
         self.job.rule.script = None
         self.job.rule.notebook = None
-        # Mock job.rules() to return an iterable containing the rule
-        self.job.rules = [self.job.rule]
 
     def test_notebook_file_transferred(self):
         """Test that notebook files are included in transfer list."""
@@ -502,8 +498,6 @@ class TestCustomTransferResources:
         self.job.rule = Mock()
         self.job.rule.script = None
         self.job.rule.notebook = None
-        # Mock job.rules() to return an iterable containing the rule
-        self.job.rules = [self.job.rule]
 
     def test_htcondor_transfer_input_files_string(self):
         """Test htcondor_transfer_input_files with comma-separated string."""
@@ -566,12 +560,12 @@ class TestCustomTransferResources:
             os.unlink(file2)
 
     def test_htcondor_transfer_input_files_with_wildcards(self):
-        """Test htcondor_transfer_input_files expands wildcards."""
+        """Test htcondor_transfer_input_files expands wildcards for individual jobs."""
         self.job.wildcards = {"module": "stats_helpers"}
         self.job.params = {}
         self.job.format_wildcards = Mock(return_value="scripts/stats_helpers.py")
 
-        # Create the file
+        # Create the file that wildcards will expand to
         os.makedirs("scripts", exist_ok=True)
         with open("scripts/stats_helpers.py", "w") as f:
             f.write("# helper module")
@@ -588,7 +582,9 @@ class TestCustomTransferResources:
 
             transfer_input, _ = self.executor._get_files_for_transfer(self.job)
 
+            # Wildcard expansion SHOULD be called for individual jobs
             self.job.format_wildcards.assert_called()
+            # The expanded path should be in the transfer list
             assert "scripts/stats_helpers.py" in transfer_input
         finally:
             os.unlink("scripts/stats_helpers.py")
@@ -663,8 +659,6 @@ class TestFileTransferLogging:
         self.job.rule = Mock()
         self.job.rule.script = None
         self.job.rule.notebook = None
-        # Mock job.rules() to return an iterable containing the rule
-        self.job.rules = [self.job.rule]
 
     def test_logs_transfer_summary(self):
         """Test that summary of transfer files is logged."""

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -2,11 +2,9 @@
 Unit tests for file transfer functionality in HTCondor executor.
 """
 
-import pytest
 import tempfile
 import os
-from unittest.mock import Mock, MagicMock, patch, call
-from pathlib import Path
+from unittest.mock import Mock
 from snakemake_executor_plugin_htcondor import Executor
 
 
@@ -27,24 +25,18 @@ class TestAddFileIfTransferable:
     def test_adds_file_not_on_shared_fs(self):
         """Test that files not on shared FS are added to transfer list."""
         transfer_list = []
-        
-        self.executor._add_file_if_transferable(
-            "/home/user/data.txt",
-            transfer_list
-        )
-        
+
+        self.executor._add_file_if_transferable("/home/user/data.txt", transfer_list)
+
         assert "/home/user/data.txt" in transfer_list
         assert len(transfer_list) == 1
 
     def test_skips_file_on_shared_fs(self):
         """Test that files on shared FS are not added to transfer list."""
         transfer_list = []
-        
-        self.executor._add_file_if_transferable(
-            "/staging/user/data.txt",
-            transfer_list
-        )
-        
+
+        self.executor._add_file_if_transferable("/staging/user/data.txt", transfer_list)
+
         assert "/staging/user/data.txt" not in transfer_list
         assert len(transfer_list) == 0
         self.executor.logger.debug.assert_called()
@@ -52,9 +44,9 @@ class TestAddFileIfTransferable:
     def test_skips_empty_filepath(self):
         """Test that empty filepaths are skipped."""
         transfer_list = []
-        
+
         self.executor._add_file_if_transferable("", transfer_list)
-        
+
         assert len(transfer_list) == 0
         # Should log that it's skipping
         self.executor.logger.debug.assert_called()
@@ -62,60 +54,47 @@ class TestAddFileIfTransferable:
     def test_skips_none_filepath(self):
         """Test that None filepaths are skipped."""
         transfer_list = []
-        
+
         self.executor._add_file_if_transferable(None, transfer_list)
-        
+
         assert len(transfer_list) == 0
 
     def test_skips_whitespace_only_filepath(self):
         """Test that whitespace-only filepaths are skipped."""
         transfer_list = []
-        
+
         self.executor._add_file_if_transferable("   ", transfer_list)
-        
+
         assert len(transfer_list) == 0
 
     def test_normalizes_path(self):
         """Test that paths are normalized before adding."""
         transfer_list = []
-        
+
         self.executor._add_file_if_transferable(
-            "/home/user/./data/../data.txt",
-            transfer_list
+            "/home/user/./data/../data.txt", transfer_list
         )
-        
+
         # Should be normalized to /home/user/data.txt
         assert "/home/user/data.txt" in transfer_list
 
     def test_deduplicates_files(self):
         """Test that duplicate files are not added multiple times."""
         transfer_list = []
-        
-        self.executor._add_file_if_transferable(
-            "/home/user/data.txt",
-            transfer_list
-        )
-        self.executor._add_file_if_transferable(
-            "/home/user/data.txt",
-            transfer_list
-        )
-        
+
+        self.executor._add_file_if_transferable("/home/user/data.txt", transfer_list)
+        self.executor._add_file_if_transferable("/home/user/data.txt", transfer_list)
+
         assert len(transfer_list) == 1
 
     def test_deduplicates_normalized_paths(self):
         """Test that normalized paths are deduplicated."""
         transfer_list = []
-        
-        self.executor._add_file_if_transferable(
-            "/home/user/data.txt",
-            transfer_list
-        )
+
+        self.executor._add_file_if_transferable("/home/user/data.txt", transfer_list)
         # Same file but with ./ in path
-        self.executor._add_file_if_transferable(
-            "/home/user/./data.txt",
-            transfer_list
-        )
-        
+        self.executor._add_file_if_transferable("/home/user/./data.txt", transfer_list)
+
         assert len(transfer_list) == 1
 
     def test_expands_wildcards_when_requested(self):
@@ -125,32 +104,27 @@ class TestAddFileIfTransferable:
         job.wildcards = {"sample": "sample1"}
         job.params = {}
         job.format_wildcards = Mock(return_value="/home/user/sample1.txt")
-        
+
         self.executor._add_file_if_transferable(
-            "/home/user/{sample}.txt",
-            transfer_list,
-            expand_wildcards=True,
-            job=job
+            "/home/user/{sample}.txt", transfer_list, expand_wildcards=True, job=job
         )
-        
+
         job.format_wildcards.assert_called_once()
         assert "/home/user/sample1.txt" in transfer_list
 
     def test_validates_file_existence_by_default(self):
         """Test that file existence is validated by default."""
         transfer_list = []
-        
+
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             tmp_path = tmp.name
-        
+
         try:
             # File exists
             self.executor._add_file_if_transferable(
-                tmp_path,
-                transfer_list,
-                validate_exists=True
+                tmp_path, transfer_list, validate_exists=True
             )
-            
+
             # Should not log warning
             self.executor.logger.warning.assert_not_called()
             assert tmp_path in transfer_list
@@ -161,13 +135,11 @@ class TestAddFileIfTransferable:
         """Test that warning is logged for nonexistent files."""
         transfer_list = []
         nonexistent = "/home/user/doesnotexist.txt"
-        
+
         self.executor._add_file_if_transferable(
-            nonexistent,
-            transfer_list,
-            validate_exists=True
+            nonexistent, transfer_list, validate_exists=True
         )
-        
+
         # Should log warning and mention the filepath
         self.executor.logger.warning.assert_called_once()
         warning_msg = self.executor.logger.warning.call_args[0][0]
@@ -176,29 +148,24 @@ class TestAddFileIfTransferable:
     def test_can_disable_existence_validation(self):
         """Test that file existence validation can be disabled."""
         transfer_list = []
-        
+
         self.executor._add_file_if_transferable(
-            "/home/user/doesnotexist.txt",
-            transfer_list,
-            validate_exists=False
+            "/home/user/doesnotexist.txt", transfer_list, validate_exists=False
         )
-        
+
         # Should not log warning when validation is disabled
         self.executor.logger.warning.assert_not_called()
 
     def test_logs_debug_messages(self):
         """Test that appropriate debug messages are logged."""
         transfer_list = []
-        
+
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             tmp_path = tmp.name
-        
+
         try:
-            self.executor._add_file_if_transferable(
-                tmp_path,
-                transfer_list
-            )
-            
+            self.executor._add_file_if_transferable(tmp_path, transfer_list)
+
             # Should log debug messages
             self.executor.logger.debug.assert_called()
         finally:
@@ -211,57 +178,53 @@ class TestParseFileList:
     def setup_method(self):
         """Setup mock executor for testing."""
         self.executor = Mock(spec=Executor)
-        
+
         # Bind the actual method to our mock
-        self.executor._parse_file_list = (
-            Executor._parse_file_list.__get__(self.executor, Executor)
+        self.executor._parse_file_list = Executor._parse_file_list.__get__(
+            self.executor, Executor
         )
 
     def test_parse_comma_separated_string(self):
         """Test parsing comma-separated string of files."""
-        result = self.executor._parse_file_list(
-            "file1.txt,file2.txt,file3.txt"
-        )
-        
+        result = self.executor._parse_file_list("file1.txt,file2.txt,file3.txt")
+
         assert result == ["file1.txt", "file2.txt", "file3.txt"]
 
     def test_parse_string_with_whitespace(self):
         """Test parsing handles whitespace correctly."""
-        result = self.executor._parse_file_list(
-            " file1.txt , file2.txt , file3.txt "
-        )
-        
+        result = self.executor._parse_file_list(" file1.txt , file2.txt , file3.txt ")
+
         assert result == ["file1.txt", "file2.txt", "file3.txt"]
 
     def test_parse_list_input(self):
         """Test that list input is returned as list."""
         input_list = ["file1.txt", "file2.txt", "file3.txt"]
         result = self.executor._parse_file_list(input_list)
-        
+
         assert result == input_list
 
     def test_parse_empty_string(self):
         """Test that empty string returns empty list."""
         result = self.executor._parse_file_list("")
-        
+
         assert result == []
 
     def test_parse_whitespace_only_string(self):
         """Test that whitespace-only string returns empty list."""
         result = self.executor._parse_file_list("  ,  , ")
-        
+
         assert result == []
 
     def test_parse_single_file(self):
         """Test parsing single file (no commas)."""
         result = self.executor._parse_file_list("file1.txt")
-        
+
         assert result == ["file1.txt"]
 
     def test_parse_empty_list(self):
         """Test that empty list input returns empty list."""
         result = self.executor._parse_file_list([])
-        
+
         assert result == []
 
 
@@ -299,15 +262,15 @@ class TestScriptTransfer:
         """Test that script files are included in transfer list."""
         with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as tmp:
             script_path = tmp.name
-        
+
         try:
             self.job.rule.script = script_path
             self.job.wildcards = {}
             self.job.params = {}
             self.job.format_wildcards = Mock(return_value=script_path)
-            
+
             transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-            
+
             assert script_path in transfer_input
         finally:
             os.unlink(script_path)
@@ -318,15 +281,15 @@ class TestScriptTransfer:
         self.job.wildcards = {"sample": "sample1"}
         self.job.params = {}
         self.job.format_wildcards = Mock(return_value="scripts/process_sample1.py")
-        
+
         # Create the actual file so validation passes
         os.makedirs("scripts", exist_ok=True)
         with open("scripts/process_sample1.py", "w") as f:
             f.write("# test script")
-        
+
         try:
             transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-            
+
             self.job.format_wildcards.assert_called()
             assert "scripts/process_sample1.py" in transfer_input
         finally:
@@ -339,18 +302,18 @@ class TestScriptTransfer:
         """Test that scripts in subdirectories preserve their relative path."""
         os.makedirs("workflow/scripts", exist_ok=True)
         script_path = "workflow/scripts/process.py"
-        
+
         with open(script_path, "w") as f:
             f.write("# test script")
-        
+
         try:
             self.job.rule.script = script_path
             self.job.wildcards = {}
             self.job.params = {}
             self.job.format_wildcards = Mock(return_value=script_path)
-            
+
             transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-            
+
             # Full relative path must be preserved
             assert script_path in transfer_input
         finally:
@@ -393,15 +356,15 @@ class TestNotebookTransfer:
         """Test that notebook files are included in transfer list."""
         with tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False) as tmp:
             notebook_path = tmp.name
-        
+
         try:
             self.job.rule.notebook = notebook_path
             self.job.wildcards = {}
             self.job.params = {}
             self.job.format_wildcards = Mock(return_value=notebook_path)
-            
+
             transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-            
+
             assert notebook_path in transfer_input
         finally:
             os.unlink(notebook_path)
@@ -440,14 +403,16 @@ class TestJobWrapperTransfer:
         """Test that job_wrapper is included in transfer list."""
         with tempfile.NamedTemporaryFile(suffix=".sh", delete=False) as tmp:
             wrapper_path = tmp.name
-        
+
         try:
             self.job.resources.get = Mock(
-                side_effect=lambda key, default=None: wrapper_path if key == "job_wrapper" else default
+                side_effect=lambda key, default=None: (
+                    wrapper_path if key == "job_wrapper" else default
+                )
             )
-            
+
             transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-            
+
             assert wrapper_path in transfer_input
         finally:
             os.unlink(wrapper_path)
@@ -456,17 +421,19 @@ class TestJobWrapperTransfer:
         """Test that job_wrapper in subdirectory preserves full path."""
         os.makedirs("workflow/wrappers", exist_ok=True)
         wrapper_path = "workflow/wrappers/htcondor.sh"
-        
+
         with open(wrapper_path, "w") as f:
             f.write("#!/bin/bash\nsnakemake $@")
-        
+
         try:
             self.job.resources.get = Mock(
-                side_effect=lambda key, default=None: wrapper_path if key == "job_wrapper" else default
+                side_effect=lambda key, default=None: (
+                    wrapper_path if key == "job_wrapper" else default
+                )
             )
-            
+
             transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-            
+
             assert wrapper_path in transfer_input
         finally:
             os.unlink(wrapper_path)
@@ -477,14 +444,16 @@ class TestJobWrapperTransfer:
         """Test that job_wrapper detection is logged."""
         with tempfile.NamedTemporaryFile(suffix=".sh", delete=False) as tmp:
             wrapper_path = tmp.name
-        
+
         try:
             self.job.resources.get = Mock(
-                side_effect=lambda key, default=None: wrapper_path if key == "job_wrapper" else default
+                side_effect=lambda key, default=None: (
+                    wrapper_path if key == "job_wrapper" else default
+                )
             )
-            
+
             self.executor._get_files_for_transfer(self.job)
-            
+
             # Should log debug messages
             self.executor.logger.debug.assert_called()
         finally:
@@ -510,8 +479,8 @@ class TestCustomTransferResources:
         self.executor._add_file_if_transferable = (
             Executor._add_file_if_transferable.__get__(self.executor, Executor)
         )
-        self.executor._parse_file_list = (
-            Executor._parse_file_list.__get__(self.executor, Executor)
+        self.executor._parse_file_list = Executor._parse_file_list.__get__(
+            self.executor, Executor
         )
 
         # Create mock job
@@ -525,23 +494,27 @@ class TestCustomTransferResources:
     def test_htcondor_transfer_input_files_string(self):
         """Test htcondor_transfer_input_files with comma-separated string."""
         # Create temporary files
-        with tempfile.NamedTemporaryFile(delete=False) as tmp1, \
-             tempfile.NamedTemporaryFile(delete=False) as tmp2:
+        with tempfile.NamedTemporaryFile(
+            delete=False
+        ) as tmp1, tempfile.NamedTemporaryFile(delete=False) as tmp2:
             file1 = tmp1.name
             file2 = tmp2.name
-        
+
         try:
             self.job.resources = Mock()
             self.job.resources.get = Mock(
-                side_effect=lambda key, default=None: 
-                    f"{file1},{file2}" if key == "htcondor_transfer_input_files" else default
+                side_effect=lambda key, default=None: (
+                    f"{file1},{file2}"
+                    if key == "htcondor_transfer_input_files"
+                    else default
+                )
             )
             self.job.wildcards = {}
             self.job.params = {}
             self.job.format_wildcards = Mock(side_effect=lambda path, **kwargs: path)
-            
+
             transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-            
+
             assert file1 in transfer_input
             assert file2 in transfer_input
         finally:
@@ -551,23 +524,27 @@ class TestCustomTransferResources:
     def test_htcondor_transfer_input_files_list(self):
         """Test htcondor_transfer_input_files with list."""
         # Create temporary files
-        with tempfile.NamedTemporaryFile(delete=False) as tmp1, \
-             tempfile.NamedTemporaryFile(delete=False) as tmp2:
+        with tempfile.NamedTemporaryFile(
+            delete=False
+        ) as tmp1, tempfile.NamedTemporaryFile(delete=False) as tmp2:
             file1 = tmp1.name
             file2 = tmp2.name
-        
+
         try:
             self.job.resources = Mock()
             self.job.resources.get = Mock(
-                side_effect=lambda key, default=None: 
-                    [file1, file2] if key == "htcondor_transfer_input_files" else default
+                side_effect=lambda key, default=None: (
+                    [file1, file2]
+                    if key == "htcondor_transfer_input_files"
+                    else default
+                )
             )
             self.job.wildcards = {}
             self.job.params = {}
             self.job.format_wildcards = Mock(side_effect=lambda path, **kwargs: path)
-            
+
             transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-            
+
             assert file1 in transfer_input
             assert file2 in transfer_input
         finally:
@@ -579,21 +556,24 @@ class TestCustomTransferResources:
         self.job.wildcards = {"module": "stats_helpers"}
         self.job.params = {}
         self.job.format_wildcards = Mock(return_value="scripts/stats_helpers.py")
-        
+
         # Create the file
         os.makedirs("scripts", exist_ok=True)
         with open("scripts/stats_helpers.py", "w") as f:
             f.write("# helper module")
-        
+
         try:
             self.job.resources = Mock()
             self.job.resources.get = Mock(
-                side_effect=lambda key, default=None: 
-                    "scripts/{module}.py" if key == "htcondor_transfer_input_files" else default
+                side_effect=lambda key, default=None: (
+                    "scripts/{module}.py"
+                    if key == "htcondor_transfer_input_files"
+                    else default
+                )
             )
-            
+
             transfer_input, _ = self.executor._get_files_for_transfer(self.job)
-            
+
             self.job.format_wildcards.assert_called()
             assert "scripts/stats_helpers.py" in transfer_input
         finally:
@@ -604,15 +584,18 @@ class TestCustomTransferResources:
         """Test htcondor_transfer_output_files with comma-separated string."""
         self.job.resources = Mock()
         self.job.resources.get = Mock(
-            side_effect=lambda key, default=None: 
-                "results/model.pkl,results/metrics.json" if key == "htcondor_transfer_output_files" else default
+            side_effect=lambda key, default=None: (
+                "results/model.pkl,results/metrics.json"
+                if key == "htcondor_transfer_output_files"
+                else default
+            )
         )
         self.job.wildcards = {}
         self.job.params = {}
         self.job.format_wildcards = Mock(side_effect=lambda path, **kwargs: path)
-        
+
         _, transfer_output = self.executor._get_files_for_transfer(self.job)
-        
+
         assert "results/model.pkl" in transfer_output
         assert "results/metrics.json" in transfer_output
 
@@ -620,15 +603,18 @@ class TestCustomTransferResources:
         """Test htcondor_transfer_output_files with list."""
         self.job.resources = Mock()
         self.job.resources.get = Mock(
-            side_effect=lambda key, default=None: 
-                ["results/model.pkl", "results/metrics.json"] if key == "htcondor_transfer_output_files" else default
+            side_effect=lambda key, default=None: (
+                ["results/model.pkl", "results/metrics.json"]
+                if key == "htcondor_transfer_output_files"
+                else default
+            )
         )
         self.job.wildcards = {}
         self.job.params = {}
         self.job.format_wildcards = Mock(side_effect=lambda path, **kwargs: path)
-        
+
         _, transfer_output = self.executor._get_files_for_transfer(self.job)
-        
+
         assert "results/model.pkl" in transfer_output
         assert "results/metrics.json" in transfer_output
 
@@ -665,14 +651,14 @@ class TestFileTransferLogging:
 
     def test_logs_transfer_summary(self):
         """Test that summary of transfer files is logged."""
-        transfer_input, transfer_output = self.executor._get_files_for_transfer(self.job)
-        
+        _ = self.executor._get_files_for_transfer(self.job)
+
         # Should log at debug level
         self.executor.logger.debug.assert_called()
 
     def test_logs_job_identifier(self):
         """Test that job identifier is logged at start."""
         self.executor._get_files_for_transfer(self.job)
-        
+
         # Should log debug messages
         self.executor.logger.debug.assert_called()

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -1,0 +1,678 @@
+"""
+Unit tests for file transfer functionality in HTCondor executor.
+"""
+
+import pytest
+import tempfile
+import os
+from unittest.mock import Mock, MagicMock, patch, call
+from pathlib import Path
+from snakemake_executor_plugin_htcondor import Executor
+
+
+class TestAddFileIfTransferable:
+    """Test the _add_file_if_transferable helper method."""
+
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+        self.executor.shared_fs_prefixes = ["/staging/", "/shared/"]
+
+        # Bind the actual method to our mock
+        self.executor._add_file_if_transferable = (
+            Executor._add_file_if_transferable.__get__(self.executor, Executor)
+        )
+
+    def test_adds_file_not_on_shared_fs(self):
+        """Test that files not on shared FS are added to transfer list."""
+        transfer_list = []
+        
+        self.executor._add_file_if_transferable(
+            "/home/user/data.txt",
+            transfer_list
+        )
+        
+        assert "/home/user/data.txt" in transfer_list
+        assert len(transfer_list) == 1
+
+    def test_skips_file_on_shared_fs(self):
+        """Test that files on shared FS are not added to transfer list."""
+        transfer_list = []
+        
+        self.executor._add_file_if_transferable(
+            "/staging/user/data.txt",
+            transfer_list
+        )
+        
+        assert "/staging/user/data.txt" not in transfer_list
+        assert len(transfer_list) == 0
+        self.executor.logger.debug.assert_called()
+
+    def test_skips_empty_filepath(self):
+        """Test that empty filepaths are skipped."""
+        transfer_list = []
+        
+        self.executor._add_file_if_transferable("", transfer_list)
+        
+        assert len(transfer_list) == 0
+        # Should log that it's skipping
+        self.executor.logger.debug.assert_called()
+
+    def test_skips_none_filepath(self):
+        """Test that None filepaths are skipped."""
+        transfer_list = []
+        
+        self.executor._add_file_if_transferable(None, transfer_list)
+        
+        assert len(transfer_list) == 0
+
+    def test_skips_whitespace_only_filepath(self):
+        """Test that whitespace-only filepaths are skipped."""
+        transfer_list = []
+        
+        self.executor._add_file_if_transferable("   ", transfer_list)
+        
+        assert len(transfer_list) == 0
+
+    def test_normalizes_path(self):
+        """Test that paths are normalized before adding."""
+        transfer_list = []
+        
+        self.executor._add_file_if_transferable(
+            "/home/user/./data/../data.txt",
+            transfer_list
+        )
+        
+        # Should be normalized to /home/user/data.txt
+        assert "/home/user/data.txt" in transfer_list
+
+    def test_deduplicates_files(self):
+        """Test that duplicate files are not added multiple times."""
+        transfer_list = []
+        
+        self.executor._add_file_if_transferable(
+            "/home/user/data.txt",
+            transfer_list
+        )
+        self.executor._add_file_if_transferable(
+            "/home/user/data.txt",
+            transfer_list
+        )
+        
+        assert len(transfer_list) == 1
+
+    def test_deduplicates_normalized_paths(self):
+        """Test that normalized paths are deduplicated."""
+        transfer_list = []
+        
+        self.executor._add_file_if_transferable(
+            "/home/user/data.txt",
+            transfer_list
+        )
+        # Same file but with ./ in path
+        self.executor._add_file_if_transferable(
+            "/home/user/./data.txt",
+            transfer_list
+        )
+        
+        assert len(transfer_list) == 1
+
+    def test_expands_wildcards_when_requested(self):
+        """Test that wildcards are expanded when expand_wildcards=True."""
+        transfer_list = []
+        job = Mock()
+        job.wildcards = {"sample": "sample1"}
+        job.params = {}
+        job.format_wildcards = Mock(return_value="/home/user/sample1.txt")
+        
+        self.executor._add_file_if_transferable(
+            "/home/user/{sample}.txt",
+            transfer_list,
+            expand_wildcards=True,
+            job=job
+        )
+        
+        job.format_wildcards.assert_called_once()
+        assert "/home/user/sample1.txt" in transfer_list
+
+    def test_validates_file_existence_by_default(self):
+        """Test that file existence is validated by default."""
+        transfer_list = []
+        
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp_path = tmp.name
+        
+        try:
+            # File exists
+            self.executor._add_file_if_transferable(
+                tmp_path,
+                transfer_list,
+                validate_exists=True
+            )
+            
+            # Should not log warning
+            self.executor.logger.warning.assert_not_called()
+            assert tmp_path in transfer_list
+        finally:
+            os.unlink(tmp_path)
+
+    def test_warns_on_nonexistent_file(self):
+        """Test that warning is logged for nonexistent files."""
+        transfer_list = []
+        nonexistent = "/home/user/doesnotexist.txt"
+        
+        self.executor._add_file_if_transferable(
+            nonexistent,
+            transfer_list,
+            validate_exists=True
+        )
+        
+        # Should log warning and mention the filepath
+        self.executor.logger.warning.assert_called_once()
+        warning_msg = self.executor.logger.warning.call_args[0][0]
+        assert nonexistent in warning_msg
+
+    def test_can_disable_existence_validation(self):
+        """Test that file existence validation can be disabled."""
+        transfer_list = []
+        
+        self.executor._add_file_if_transferable(
+            "/home/user/doesnotexist.txt",
+            transfer_list,
+            validate_exists=False
+        )
+        
+        # Should not log warning when validation is disabled
+        self.executor.logger.warning.assert_not_called()
+
+    def test_logs_debug_messages(self):
+        """Test that appropriate debug messages are logged."""
+        transfer_list = []
+        
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp_path = tmp.name
+        
+        try:
+            self.executor._add_file_if_transferable(
+                tmp_path,
+                transfer_list
+            )
+            
+            # Should log debug messages
+            self.executor.logger.debug.assert_called()
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestParseFileList:
+    """Test the _parse_file_list helper method."""
+
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = Mock(spec=Executor)
+        
+        # Bind the actual method to our mock
+        self.executor._parse_file_list = (
+            Executor._parse_file_list.__get__(self.executor, Executor)
+        )
+
+    def test_parse_comma_separated_string(self):
+        """Test parsing comma-separated string of files."""
+        result = self.executor._parse_file_list(
+            "file1.txt,file2.txt,file3.txt"
+        )
+        
+        assert result == ["file1.txt", "file2.txt", "file3.txt"]
+
+    def test_parse_string_with_whitespace(self):
+        """Test parsing handles whitespace correctly."""
+        result = self.executor._parse_file_list(
+            " file1.txt , file2.txt , file3.txt "
+        )
+        
+        assert result == ["file1.txt", "file2.txt", "file3.txt"]
+
+    def test_parse_list_input(self):
+        """Test that list input is returned as list."""
+        input_list = ["file1.txt", "file2.txt", "file3.txt"]
+        result = self.executor._parse_file_list(input_list)
+        
+        assert result == input_list
+
+    def test_parse_empty_string(self):
+        """Test that empty string returns empty list."""
+        result = self.executor._parse_file_list("")
+        
+        assert result == []
+
+    def test_parse_whitespace_only_string(self):
+        """Test that whitespace-only string returns empty list."""
+        result = self.executor._parse_file_list("  ,  , ")
+        
+        assert result == []
+
+    def test_parse_single_file(self):
+        """Test parsing single file (no commas)."""
+        result = self.executor._parse_file_list("file1.txt")
+        
+        assert result == ["file1.txt"]
+
+    def test_parse_empty_list(self):
+        """Test that empty list input returns empty list."""
+        result = self.executor._parse_file_list([])
+        
+        assert result == []
+
+
+class TestScriptTransfer:
+    """Test that script files from the script: directive are transferred."""
+
+    def setup_method(self):
+        """Setup mock executor and job for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+        self.executor.shared_fs_prefixes = []
+        self.executor.workflow = Mock()
+        self.executor.workflow.configfiles = []
+        self.executor.get_snakefile = Mock(return_value="Snakefile")
+
+        # Bind the actual methods to our mock
+        self.executor._get_files_for_transfer = (
+            Executor._get_files_for_transfer.__get__(self.executor, Executor)
+        )
+        self.executor._add_file_if_transferable = (
+            Executor._add_file_if_transferable.__get__(self.executor, Executor)
+        )
+
+        # Create mock job
+        self.job = Mock()
+        self.job.input = []
+        self.job.output = []
+        self.job.resources = Mock()
+        self.job.resources.get = Mock(return_value=None)
+        self.job.rule = Mock()
+        self.job.rule.script = None
+        self.job.rule.notebook = None
+
+    def test_script_file_transferred(self):
+        """Test that script files are included in transfer list."""
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as tmp:
+            script_path = tmp.name
+        
+        try:
+            self.job.rule.script = script_path
+            self.job.wildcards = {}
+            self.job.params = {}
+            self.job.format_wildcards = Mock(return_value=script_path)
+            
+            transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+            
+            assert script_path in transfer_input
+        finally:
+            os.unlink(script_path)
+
+    def test_script_with_wildcards_expanded(self):
+        """Test that script paths with wildcards are expanded."""
+        self.job.rule.script = "scripts/process_{sample}.py"
+        self.job.wildcards = {"sample": "sample1"}
+        self.job.params = {}
+        self.job.format_wildcards = Mock(return_value="scripts/process_sample1.py")
+        
+        # Create the actual file so validation passes
+        os.makedirs("scripts", exist_ok=True)
+        with open("scripts/process_sample1.py", "w") as f:
+            f.write("# test script")
+        
+        try:
+            transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+            
+            self.job.format_wildcards.assert_called()
+            assert "scripts/process_sample1.py" in transfer_input
+        finally:
+            if os.path.exists("scripts/process_sample1.py"):
+                os.unlink("scripts/process_sample1.py")
+            if os.path.exists("scripts") and not os.listdir("scripts"):
+                os.rmdir("scripts")
+
+    def test_script_in_subdirectory_preserves_path(self):
+        """Test that scripts in subdirectories preserve their relative path."""
+        os.makedirs("workflow/scripts", exist_ok=True)
+        script_path = "workflow/scripts/process.py"
+        
+        with open(script_path, "w") as f:
+            f.write("# test script")
+        
+        try:
+            self.job.rule.script = script_path
+            self.job.wildcards = {}
+            self.job.params = {}
+            self.job.format_wildcards = Mock(return_value=script_path)
+            
+            transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+            
+            # Full relative path must be preserved
+            assert script_path in transfer_input
+        finally:
+            os.unlink(script_path)
+            os.rmdir("workflow/scripts")
+            os.rmdir("workflow")
+
+
+class TestNotebookTransfer:
+    """Test that notebook files from the notebook: directive are transferred."""
+
+    def setup_method(self):
+        """Setup mock executor and job for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+        self.executor.shared_fs_prefixes = []
+        self.executor.workflow = Mock()
+        self.executor.workflow.configfiles = []
+        self.executor.get_snakefile = Mock(return_value="Snakefile")
+
+        # Bind the actual methods
+        self.executor._get_files_for_transfer = (
+            Executor._get_files_for_transfer.__get__(self.executor, Executor)
+        )
+        self.executor._add_file_if_transferable = (
+            Executor._add_file_if_transferable.__get__(self.executor, Executor)
+        )
+
+        # Create mock job
+        self.job = Mock()
+        self.job.input = []
+        self.job.output = []
+        self.job.resources = Mock()
+        self.job.resources.get = Mock(return_value=None)
+        self.job.rule = Mock()
+        self.job.rule.script = None
+        self.job.rule.notebook = None
+
+    def test_notebook_file_transferred(self):
+        """Test that notebook files are included in transfer list."""
+        with tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False) as tmp:
+            notebook_path = tmp.name
+        
+        try:
+            self.job.rule.notebook = notebook_path
+            self.job.wildcards = {}
+            self.job.params = {}
+            self.job.format_wildcards = Mock(return_value=notebook_path)
+            
+            transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+            
+            assert notebook_path in transfer_input
+        finally:
+            os.unlink(notebook_path)
+
+
+class TestJobWrapperTransfer:
+    """Test that job_wrapper resource is explicitly transferred."""
+
+    def setup_method(self):
+        """Setup mock executor and job for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+        self.executor.shared_fs_prefixes = []
+        self.executor.workflow = Mock()
+        self.executor.workflow.configfiles = []
+        self.executor.get_snakefile = Mock(return_value="Snakefile")
+
+        # Bind the actual methods
+        self.executor._get_files_for_transfer = (
+            Executor._get_files_for_transfer.__get__(self.executor, Executor)
+        )
+        self.executor._add_file_if_transferable = (
+            Executor._add_file_if_transferable.__get__(self.executor, Executor)
+        )
+
+        # Create mock job
+        self.job = Mock()
+        self.job.input = []
+        self.job.output = []
+        self.job.resources = Mock()
+        self.job.rule = Mock()
+        self.job.rule.script = None
+        self.job.rule.notebook = None
+
+    def test_job_wrapper_transferred(self):
+        """Test that job_wrapper is included in transfer list."""
+        with tempfile.NamedTemporaryFile(suffix=".sh", delete=False) as tmp:
+            wrapper_path = tmp.name
+        
+        try:
+            self.job.resources.get = Mock(
+                side_effect=lambda key, default=None: wrapper_path if key == "job_wrapper" else default
+            )
+            
+            transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+            
+            assert wrapper_path in transfer_input
+        finally:
+            os.unlink(wrapper_path)
+
+    def test_job_wrapper_in_subdirectory(self):
+        """Test that job_wrapper in subdirectory preserves full path."""
+        os.makedirs("workflow/wrappers", exist_ok=True)
+        wrapper_path = "workflow/wrappers/htcondor.sh"
+        
+        with open(wrapper_path, "w") as f:
+            f.write("#!/bin/bash\nsnakemake $@")
+        
+        try:
+            self.job.resources.get = Mock(
+                side_effect=lambda key, default=None: wrapper_path if key == "job_wrapper" else default
+            )
+            
+            transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+            
+            assert wrapper_path in transfer_input
+        finally:
+            os.unlink(wrapper_path)
+            os.rmdir("workflow/wrappers")
+            os.rmdir("workflow")
+
+    def test_job_wrapper_logs_debug(self):
+        """Test that job_wrapper detection is logged."""
+        with tempfile.NamedTemporaryFile(suffix=".sh", delete=False) as tmp:
+            wrapper_path = tmp.name
+        
+        try:
+            self.job.resources.get = Mock(
+                side_effect=lambda key, default=None: wrapper_path if key == "job_wrapper" else default
+            )
+            
+            self.executor._get_files_for_transfer(self.job)
+            
+            # Should log debug messages
+            self.executor.logger.debug.assert_called()
+        finally:
+            os.unlink(wrapper_path)
+
+
+class TestCustomTransferResources:
+    """Test htcondor_transfer_input_files and htcondor_transfer_output_files resources."""
+
+    def setup_method(self):
+        """Setup mock executor and job for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+        self.executor.shared_fs_prefixes = []
+        self.executor.workflow = Mock()
+        self.executor.workflow.configfiles = []
+        self.executor.get_snakefile = Mock(return_value="Snakefile")
+
+        # Bind the actual methods
+        self.executor._get_files_for_transfer = (
+            Executor._get_files_for_transfer.__get__(self.executor, Executor)
+        )
+        self.executor._add_file_if_transferable = (
+            Executor._add_file_if_transferable.__get__(self.executor, Executor)
+        )
+        self.executor._parse_file_list = (
+            Executor._parse_file_list.__get__(self.executor, Executor)
+        )
+
+        # Create mock job
+        self.job = Mock()
+        self.job.input = []
+        self.job.output = []
+        self.job.rule = Mock()
+        self.job.rule.script = None
+        self.job.rule.notebook = None
+
+    def test_htcondor_transfer_input_files_string(self):
+        """Test htcondor_transfer_input_files with comma-separated string."""
+        # Create temporary files
+        with tempfile.NamedTemporaryFile(delete=False) as tmp1, \
+             tempfile.NamedTemporaryFile(delete=False) as tmp2:
+            file1 = tmp1.name
+            file2 = tmp2.name
+        
+        try:
+            self.job.resources = Mock()
+            self.job.resources.get = Mock(
+                side_effect=lambda key, default=None: 
+                    f"{file1},{file2}" if key == "htcondor_transfer_input_files" else default
+            )
+            self.job.wildcards = {}
+            self.job.params = {}
+            self.job.format_wildcards = Mock(side_effect=lambda path, **kwargs: path)
+            
+            transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+            
+            assert file1 in transfer_input
+            assert file2 in transfer_input
+        finally:
+            os.unlink(file1)
+            os.unlink(file2)
+
+    def test_htcondor_transfer_input_files_list(self):
+        """Test htcondor_transfer_input_files with list."""
+        # Create temporary files
+        with tempfile.NamedTemporaryFile(delete=False) as tmp1, \
+             tempfile.NamedTemporaryFile(delete=False) as tmp2:
+            file1 = tmp1.name
+            file2 = tmp2.name
+        
+        try:
+            self.job.resources = Mock()
+            self.job.resources.get = Mock(
+                side_effect=lambda key, default=None: 
+                    [file1, file2] if key == "htcondor_transfer_input_files" else default
+            )
+            self.job.wildcards = {}
+            self.job.params = {}
+            self.job.format_wildcards = Mock(side_effect=lambda path, **kwargs: path)
+            
+            transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+            
+            assert file1 in transfer_input
+            assert file2 in transfer_input
+        finally:
+            os.unlink(file1)
+            os.unlink(file2)
+
+    def test_htcondor_transfer_input_files_with_wildcards(self):
+        """Test htcondor_transfer_input_files expands wildcards."""
+        self.job.wildcards = {"module": "stats_helpers"}
+        self.job.params = {}
+        self.job.format_wildcards = Mock(return_value="scripts/stats_helpers.py")
+        
+        # Create the file
+        os.makedirs("scripts", exist_ok=True)
+        with open("scripts/stats_helpers.py", "w") as f:
+            f.write("# helper module")
+        
+        try:
+            self.job.resources = Mock()
+            self.job.resources.get = Mock(
+                side_effect=lambda key, default=None: 
+                    "scripts/{module}.py" if key == "htcondor_transfer_input_files" else default
+            )
+            
+            transfer_input, _ = self.executor._get_files_for_transfer(self.job)
+            
+            self.job.format_wildcards.assert_called()
+            assert "scripts/stats_helpers.py" in transfer_input
+        finally:
+            os.unlink("scripts/stats_helpers.py")
+            os.rmdir("scripts")
+
+    def test_htcondor_transfer_output_files_string(self):
+        """Test htcondor_transfer_output_files with comma-separated string."""
+        self.job.resources = Mock()
+        self.job.resources.get = Mock(
+            side_effect=lambda key, default=None: 
+                "results/model.pkl,results/metrics.json" if key == "htcondor_transfer_output_files" else default
+        )
+        self.job.wildcards = {}
+        self.job.params = {}
+        self.job.format_wildcards = Mock(side_effect=lambda path, **kwargs: path)
+        
+        _, transfer_output = self.executor._get_files_for_transfer(self.job)
+        
+        assert "results/model.pkl" in transfer_output
+        assert "results/metrics.json" in transfer_output
+
+    def test_htcondor_transfer_output_files_list(self):
+        """Test htcondor_transfer_output_files with list."""
+        self.job.resources = Mock()
+        self.job.resources.get = Mock(
+            side_effect=lambda key, default=None: 
+                ["results/model.pkl", "results/metrics.json"] if key == "htcondor_transfer_output_files" else default
+        )
+        self.job.wildcards = {}
+        self.job.params = {}
+        self.job.format_wildcards = Mock(side_effect=lambda path, **kwargs: path)
+        
+        _, transfer_output = self.executor._get_files_for_transfer(self.job)
+        
+        assert "results/model.pkl" in transfer_output
+        assert "results/metrics.json" in transfer_output
+
+
+class TestFileTransferLogging:
+    """Test that file transfer operations log appropriately."""
+
+    def setup_method(self):
+        """Setup mock executor and job for testing."""
+        self.executor = Mock(spec=Executor)
+        self.executor.logger = Mock()
+        self.executor.shared_fs_prefixes = []
+        self.executor.workflow = Mock()
+        self.executor.workflow.configfiles = []
+        self.executor.get_snakefile = Mock(return_value="Snakefile")
+
+        # Bind the actual method
+        self.executor._get_files_for_transfer = (
+            Executor._get_files_for_transfer.__get__(self.executor, Executor)
+        )
+        self.executor._add_file_if_transferable = (
+            Executor._add_file_if_transferable.__get__(self.executor, Executor)
+        )
+
+        # Create mock job
+        self.job = Mock()
+        self.job.input = []
+        self.job.output = []
+        self.job.resources = Mock()
+        self.job.resources.get = Mock(return_value=None)
+        self.job.rule = Mock()
+        self.job.rule.script = None
+        self.job.rule.notebook = None
+
+    def test_logs_transfer_summary(self):
+        """Test that summary of transfer files is logged."""
+        transfer_input, transfer_output = self.executor._get_files_for_transfer(self.job)
+        
+        # Should log at debug level
+        self.executor.logger.debug.assert_called()
+
+    def test_logs_job_identifier(self):
+        """Test that job identifier is logged at start."""
+        self.executor._get_files_for_transfer(self.job)
+        
+        # Should log debug messages
+        self.executor.logger.debug.assert_called()

--- a/tests/test_grouped_jobs.py
+++ b/tests/test_grouped_jobs.py
@@ -1,0 +1,363 @@
+"""
+Unit tests for grouped job file transfer functionality in HTCondor executor.
+"""
+
+import tempfile
+import os
+from conftest import (
+    create_mock_executor,
+    create_mock_individual_job,
+    create_mock_group_job,
+)
+
+
+class TestGroupedJobScriptTransfer:
+    """Test that script files from grouped jobs are transferred correctly."""
+
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = create_mock_executor()
+
+    def test_single_job_with_script_in_group(self):
+        """Test that a script from a single job in a group is transferred."""
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as tmp:
+            script_path = tmp.name
+
+        try:
+            # Create individual job with script
+            individual_job = create_mock_individual_job(script=script_path)
+
+            # Create group containing this job
+            group_job = create_mock_group_job([individual_job])
+
+            transfer_input, _ = self.executor._get_files_for_transfer(group_job)
+
+            assert script_path in transfer_input
+        finally:
+            os.unlink(script_path)
+
+    def test_multiple_jobs_with_scripts_in_group(self):
+        """Test that scripts from multiple jobs in a group are all transferred."""
+        script_files = []
+        try:
+            # Create 3 jobs each with their own script
+            for i in range(3):
+                tmp = tempfile.NamedTemporaryFile(suffix=f"_job{i}.py", delete=False)
+                script_files.append(tmp.name)
+                tmp.close()
+
+            individual_jobs = [
+                create_mock_individual_job(script=script_files[0]),
+                create_mock_individual_job(script=script_files[1]),
+                create_mock_individual_job(script=script_files[2]),
+            ]
+
+            group_job = create_mock_group_job(individual_jobs)
+
+            transfer_input, _ = self.executor._get_files_for_transfer(group_job)
+
+            # All three scripts should be in the transfer list
+            for script in script_files:
+                assert script in transfer_input
+        finally:
+            for script in script_files:
+                if os.path.exists(script):
+                    os.unlink(script)
+
+    def test_mixed_jobs_with_and_without_scripts(self):
+        """Test group with some jobs having scripts and some not."""
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as tmp:
+            script_path = tmp.name
+
+        try:
+            individual_jobs = [
+                create_mock_individual_job(script=script_path),  # Has script
+                create_mock_individual_job(script=None),  # No script
+                create_mock_individual_job(script=None),  # No script
+            ]
+
+            group_job = create_mock_group_job(individual_jobs)
+
+            transfer_input, _ = self.executor._get_files_for_transfer(group_job)
+
+            # Only the one script should be transferred
+            assert script_path in transfer_input
+            assert len([f for f in transfer_input if f.endswith(".py")]) == 1
+        finally:
+            os.unlink(script_path)
+
+    def test_grouped_job_with_wildcard_script_paths(self):
+        """Test that wildcard expansion works for scripts in grouped jobs."""
+        # Create actual script files with wildcards in names
+        script_files = []
+        try:
+            for sample in ["sample1", "sample2"]:
+                tmp = tempfile.NamedTemporaryFile(
+                    suffix=f"_process_{sample}.py", delete=False
+                )
+                script_files.append(tmp.name)
+                tmp.close()
+
+            individual_jobs = [
+                create_mock_individual_job(
+                    script="scripts/process_{wildcards.sample}.py",
+                    wildcards={"sample": "sample1"},
+                ),
+                create_mock_individual_job(
+                    script="scripts/process_{wildcards.sample}.py",
+                    wildcards={"sample": "sample2"},
+                ),
+            ]
+
+            # Mock the format_wildcards for each job to expand properly
+            individual_jobs[0].format_wildcards = (
+                lambda s, **kw: "scripts/process_sample1.py"
+            )
+            individual_jobs[1].format_wildcards = (
+                lambda s, **kw: "scripts/process_sample2.py"
+            )
+
+            group_job = create_mock_group_job(individual_jobs)
+
+            transfer_input, _ = self.executor._get_files_for_transfer(group_job)
+
+            # Both expanded script paths should be in transfer list
+            assert "scripts/process_sample1.py" in transfer_input
+            assert "scripts/process_sample2.py" in transfer_input
+        finally:
+            for script in script_files:
+                if os.path.exists(script):
+                    os.unlink(script)
+
+
+class TestGroupedJobNotebookTransfer:
+    """Test that notebook files from grouped jobs are transferred correctly."""
+
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = create_mock_executor()
+
+    def test_single_job_with_notebook_in_group(self):
+        """Test that a notebook from a single job in a group is transferred."""
+        with tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False) as tmp:
+            notebook_path = tmp.name
+
+        try:
+            individual_job = create_mock_individual_job(notebook=notebook_path)
+            group_job = create_mock_group_job([individual_job])
+
+            transfer_input, _ = self.executor._get_files_for_transfer(group_job)
+
+            assert notebook_path in transfer_input
+        finally:
+            os.unlink(notebook_path)
+
+    def test_multiple_jobs_with_notebooks_in_group(self):
+        """Test that notebooks from multiple jobs in a group are all transferred."""
+        notebook_files = []
+        try:
+            for i in range(2):
+                tmp = tempfile.NamedTemporaryFile(
+                    suffix=f"_analysis{i}.ipynb", delete=False
+                )
+                notebook_files.append(tmp.name)
+                tmp.close()
+
+            individual_jobs = [
+                create_mock_individual_job(notebook=notebook_files[0]),
+                create_mock_individual_job(notebook=notebook_files[1]),
+            ]
+
+            group_job = create_mock_group_job(individual_jobs)
+
+            transfer_input, _ = self.executor._get_files_for_transfer(group_job)
+
+            for notebook in notebook_files:
+                assert notebook in transfer_input
+        finally:
+            for notebook in notebook_files:
+                if os.path.exists(notebook):
+                    os.unlink(notebook)
+
+    def test_grouped_job_with_both_scripts_and_notebooks(self):
+        """Test group with jobs having both scripts and notebooks."""
+        script_path = None
+        notebook_path = None
+
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as tmp:
+                script_path = tmp.name
+            with tempfile.NamedTemporaryFile(suffix=".ipynb", delete=False) as tmp:
+                notebook_path = tmp.name
+
+            individual_jobs = [
+                create_mock_individual_job(script=script_path),
+                create_mock_individual_job(notebook=notebook_path),
+            ]
+
+            group_job = create_mock_group_job(individual_jobs)
+
+            transfer_input, _ = self.executor._get_files_for_transfer(group_job)
+
+            # Both script and notebook should be transferred
+            assert script_path in transfer_input
+            assert notebook_path in transfer_input
+        finally:
+            if script_path and os.path.exists(script_path):
+                os.unlink(script_path)
+            if notebook_path and os.path.exists(notebook_path):
+                os.unlink(notebook_path)
+
+
+class TestGroupedJobInputOutputTransfer:
+    """Test that input/output files from grouped jobs are transferred correctly."""
+
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = create_mock_executor()
+
+    def test_combined_inputs_from_grouped_jobs(self):
+        """Test that inputs from all jobs in a group are collected."""
+        input1 = tempfile.NamedTemporaryFile(delete=False)
+        input2 = tempfile.NamedTemporaryFile(delete=False)
+
+        try:
+            individual_jobs = [
+                create_mock_individual_job(input_files=[input1.name]),
+                create_mock_individual_job(input_files=[input2.name]),
+            ]
+
+            group_job = create_mock_group_job(individual_jobs)
+
+            transfer_input, _ = self.executor._get_files_for_transfer(group_job)
+
+            assert input1.name in transfer_input
+            assert input2.name in transfer_input
+        finally:
+            input1.close()
+            input2.close()
+            os.unlink(input1.name)
+            os.unlink(input2.name)
+
+    def test_combined_outputs_from_grouped_jobs(self):
+        """Test that output directories from all jobs in a group are collected."""
+        individual_jobs = [
+            create_mock_individual_job(output_files=["output/job1_result.txt"]),
+            create_mock_individual_job(output_files=["results/job2_data.csv"]),
+        ]
+
+        group_job = create_mock_group_job(individual_jobs)
+
+        _, transfer_output = self.executor._get_files_for_transfer(group_job)
+
+        # Top-level output directories should be transferred
+        assert "output" in transfer_output
+        assert "results" in transfer_output
+
+
+class TestGroupedJobCustomTransferResources:
+    """Test that custom transfer resources work with grouped jobs."""
+
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = create_mock_executor()
+
+    def test_htcondor_transfer_input_files_on_group(self):
+        """Test that htcondor_transfer_input_files resource works on group jobs."""
+        helper_file = tempfile.NamedTemporaryFile(suffix=".py", delete=False)
+
+        try:
+            individual_jobs = [
+                create_mock_individual_job(),
+                create_mock_individual_job(),
+            ]
+
+            # Add custom transfer files at the group level
+            group_job = create_mock_group_job(
+                individual_jobs, htcondor_transfer_input_files=helper_file.name
+            )
+
+            transfer_input, _ = self.executor._get_files_for_transfer(group_job)
+
+            assert helper_file.name in transfer_input
+        finally:
+            helper_file.close()
+            os.unlink(helper_file.name)
+
+    def test_htcondor_transfer_output_files_on_group(self):
+        """Test that htcondor_transfer_output_files resource works on group jobs."""
+        individual_jobs = [
+            create_mock_individual_job(),
+            create_mock_individual_job(),
+        ]
+
+        group_job = create_mock_group_job(
+            individual_jobs, htcondor_transfer_output_files="logs/,debug/"
+        )
+
+        _, transfer_output = self.executor._get_files_for_transfer(group_job)
+
+        # Note: _parse_file_list strips trailing slashes
+        assert "logs" in transfer_output
+        assert "debug" in transfer_output
+
+
+class TestGroupedJobComplexScenarios:
+    """Test complex scenarios combining multiple features for grouped jobs."""
+
+    def setup_method(self):
+        """Setup mock executor for testing."""
+        self.executor = create_mock_executor()
+
+    def test_full_pipeline_grouped_job(self):
+        """Test a realistic grouped job with scripts, inputs, outputs, and custom transfers."""
+        script1 = tempfile.NamedTemporaryFile(suffix="_step1.py", delete=False)
+        script2 = tempfile.NamedTemporaryFile(suffix="_step2.py", delete=False)
+        input_file = tempfile.NamedTemporaryFile(suffix="_input.txt", delete=False)
+        helper = tempfile.NamedTemporaryFile(suffix="_helpers.py", delete=False)
+
+        try:
+            individual_jobs = [
+                create_mock_individual_job(
+                    script=script1.name,
+                    input_files=[input_file.name],
+                    output_files=["intermediate/step1_result.txt"],
+                ),
+                create_mock_individual_job(
+                    script=script2.name,
+                    input_files=["intermediate/step1_result.txt"],
+                    output_files=["output/final_result.txt"],
+                ),
+            ]
+
+            group_job = create_mock_group_job(
+                individual_jobs, htcondor_transfer_input_files=helper.name
+            )
+
+            transfer_input, transfer_output = self.executor._get_files_for_transfer(
+                group_job
+            )
+
+            # Verify all expected files are in transfer lists
+            assert script1.name in transfer_input
+            assert script2.name in transfer_input
+            assert input_file.name in transfer_input
+            assert helper.name in transfer_input
+            assert "intermediate" in transfer_output
+            assert "output" in transfer_output
+        finally:
+            for f in [script1, script2, input_file, helper]:
+                f.close()
+                os.unlink(f.name)
+
+    def test_empty_group_job(self):
+        """Test that an empty group job doesn't cause errors."""
+        group_job = create_mock_group_job([])
+
+        transfer_input, transfer_output = self.executor._get_files_for_transfer(
+            group_job
+        )
+
+        # Should complete without errors, returning empty or minimal transfers
+        assert isinstance(transfer_input, list)
+        assert isinstance(transfer_output, list)

--- a/tests/test_job_wrapper.py
+++ b/tests/test_job_wrapper.py
@@ -89,8 +89,10 @@ class TestGetBaseExecAndArgs:
 
         # Should use sys.executable (full path to Python)
         import sys
+
         assert job_exec == sys.executable
-        self.executor.get_python_executable.assert_called_once()
+        # Note: get_python_executable() is only called as a fallback if other
+        # prefix matches fail, so we don't assert it was called
 
     def test_wrapper_strips_snakemake_prefix_from_args(self):
         """Test that with wrapper, 'python -m snakemake ' prefix is stripped."""
@@ -112,9 +114,10 @@ class TestGetBaseExecAndArgs:
         job.resources = Mock()
         job.resources.get = Mock(return_value=None)
         self.executor.get_python_executable = Mock(return_value="/usr/bin/python3")
-        
+
         # Use sys.executable in the mock return value to match reality
         import sys
+
         self.executor.format_job_exec = Mock(
             return_value=f"{sys.executable} -m snakemake --snakefile Snakefile"
         )
@@ -295,4 +298,5 @@ class TestJobWrapperEdgeCases:
 
         # Empty string is falsy, so should use sys.executable
         import sys
+
         assert job_exec == sys.executable

--- a/tests/test_job_wrapper.py
+++ b/tests/test_job_wrapper.py
@@ -87,7 +87,9 @@ class TestGetBaseExecAndArgs:
 
         job_exec, _ = self.executor._get_base_exec_and_args(job)
 
-        assert job_exec == "python"
+        # Should use sys.executable (full path to Python)
+        import sys
+        assert job_exec == sys.executable
         self.executor.get_python_executable.assert_called_once()
 
     def test_wrapper_strips_snakemake_prefix_from_args(self):
@@ -110,13 +112,17 @@ class TestGetBaseExecAndArgs:
         job.resources = Mock()
         job.resources.get = Mock(return_value=None)
         self.executor.get_python_executable = Mock(return_value="/usr/bin/python3")
+        
+        # Use sys.executable in the mock return value to match reality
+        import sys
         self.executor.format_job_exec = Mock(
-            return_value="/usr/bin/python3 -m snakemake --snakefile Snakefile"
+            return_value=f"{sys.executable} -m snakemake --snakefile Snakefile"
         )
 
         job_exec, job_args = self.executor._get_base_exec_and_args(job)
 
-        assert job_exec == "/usr/bin/python3"
+        # Should use sys.executable, not get_python_executable()
+        assert job_exec == sys.executable
         assert job_args == "-m snakemake --snakefile Snakefile"
 
 
@@ -287,5 +293,6 @@ class TestJobWrapperEdgeCases:
 
         job_exec, _ = self.executor._get_base_exec_and_args(job)
 
-        # Empty string is falsy, so should use Python
-        assert job_exec == "python"
+        # Empty string is falsy, so should use sys.executable
+        import sys
+        assert job_exec == sys.executable

--- a/tests/test_shared_fs.py
+++ b/tests/test_shared_fs.py
@@ -139,6 +139,7 @@ class TestGetFilesForTransfer:
 
         # Create mock job
         self.job = Mock()
+        self.job.is_group = Mock(return_value=False)
         self.job.input = []
         self.job.output = []
         self.job.resources = Mock()
@@ -148,6 +149,9 @@ class TestGetFilesForTransfer:
         self.job.rule = Mock()
         self.job.rule.script = None
         self.job.rule.notebook = None
+        # Mock job.rules() to return an iterable containing the rule
+        # This is needed because the code iterates through job.rules()
+        self.job.rules = [self.job.rule]
 
     def test_snakefile_not_on_shared_fs(self):
         """Test that Snakefile not on shared FS is included in transfer."""
@@ -262,6 +266,8 @@ class TestGetFilesForTransfer:
         self.job.rule = Mock()
         self.job.rule.script = "scripts/process.py"
         self.job.rule.notebook = None
+        # Update job.rules to reflect the new rule
+        self.job.rules = [self.job.rule]
         self.job.wildcards = {}
         self.job.params = {}
         self.job.format_wildcards = Mock(return_value="scripts/process.py")
@@ -277,6 +283,8 @@ class TestGetFilesForTransfer:
         self.job.rule = Mock()
         self.job.rule.script = None
         self.job.rule.notebook = "notebooks/analysis.ipynb"
+        # Update job.rules to reflect the new rule
+        self.job.rules = [self.job.rule]
         self.job.wildcards = {}
         self.job.params = {}
         self.job.format_wildcards = Mock(return_value="notebooks/analysis.ipynb")

--- a/tests/test_shared_fs.py
+++ b/tests/test_shared_fs.py
@@ -149,9 +149,6 @@ class TestGetFilesForTransfer:
         self.job.rule = Mock()
         self.job.rule.script = None
         self.job.rule.notebook = None
-        # Mock job.rules() to return an iterable containing the rule
-        # This is needed because the code iterates through job.rules()
-        self.job.rules = [self.job.rule]
 
     def test_snakefile_not_on_shared_fs(self):
         """Test that Snakefile not on shared FS is included in transfer."""
@@ -266,8 +263,6 @@ class TestGetFilesForTransfer:
         self.job.rule = Mock()
         self.job.rule.script = "scripts/process.py"
         self.job.rule.notebook = None
-        # Update job.rules to reflect the new rule
-        self.job.rules = [self.job.rule]
         self.job.wildcards = {}
         self.job.params = {}
         self.job.format_wildcards = Mock(return_value="scripts/process.py")
@@ -283,8 +278,6 @@ class TestGetFilesForTransfer:
         self.job.rule = Mock()
         self.job.rule.script = None
         self.job.rule.notebook = "notebooks/analysis.ipynb"
-        # Update job.rules to reflect the new rule
-        self.job.rules = [self.job.rule]
         self.job.wildcards = {}
         self.job.params = {}
         self.job.format_wildcards = Mock(return_value="notebooks/analysis.ipynb")


### PR DESCRIPTION
A few new things going on here

First, the executor now detects when rules declare a `script`, and adds these to the `transfer_input_files` key for the submit description if needed. Claude suggested I do the same for rule notebooks, and while I didn't test this, I decided to add it during this pass because it seemed reasonable and probably correct. Note that both of these support wildcards, so the executor had to handle wildcard expansion outside of Snakemake proper.

Second, I'm assuming I'll never be able to detect every file that needs to be transferred (my local counter example for testing was using a rule script that imports a function from another python file I created). This means I needed to add a way for users to declare these files themselves. Toward that end, I added two new types of `resource` attributes called `htcondor_transfer_input_files` and `htcondor_transfer_output_files` that can be used to specify extra files to be transferred as input or output in addition to any files detected by the executor.

Finally, while I was constructing Snakefiles to test these new features locally, I realized that when rules don't use a job wrapper but run without a shared filesystem, the executor was setting `executable=python` in the submit description. HTCondor interprets this as "there is an executable in the submit directory called 'python' that I should transfer", which is obviously incorrect. To work around that, I get the executable path for Python and transfer that instead.

Tests here were written by Claude and spot-checked, but not intensively verified because I'm budgeting time with this. I did test the core features manually.