### PR TITLE
fix: Use --wrap keep to preserve one-sentence-per-line formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,9 @@ repos:
     hooks:
     -   id: mdformat
         name: Format markdown files
-        args: [--wrap, "no"]
+        additional_dependencies:
+        -   mdformat-simple-breaks
+        args: [--wrap, "keep"] #leaves line breaks exactly as what's written
         files: \.md$
-        #excluding docs as well to prevent unintentionally break in text format
+        #excluding docs as well to prevent unintentional break in text format
         exclude: (\.mdx$|^docs)


### PR DESCRIPTION
## Summary
Changed mdformat `--wrap` option from `no` to `keep` to preserve manual one-sentence-per-line formatting

## Context
According to my research, there is no mdformat option that automatically enforces one-sentence-per-line. The `--wrap keep` preserves line breaks as written, so manually formatted one-sentence-per-line text won't be joined together.

I also added `mdformat-simple-breaks` as additional dependency in case there is `<br>` or `<hr>` HTML tag that are preferred to be converted to backslash, but this is not related to one-sentence-per-line.

Related to #31
