### PR TITLE
feat: Add a warning when detecting absolute path with preserve_relative_paths=True

### DIFF
--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -546,6 +546,13 @@ class Executor(RemoteExecutor):
             f"Transfer input files: {transfer_input_files}\n"
             f"Transfer output files: {transfer_output_files}"
         )
+
+        # Warning for the absolute paths getting flatten after being sent to HTCondor
+        if job.resources.get("preserve_relative_paths", True):
+            abs_paths = [p for p in transfer_input_files if isabs(p)]
+            if abs_paths:
+                self.logger.warning(f"Absolute paths will be flattened: {abs_paths}")
+
         return transfer_input_files, transfer_output_files
 
     def _prepare_config_files_for_transfer(

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -547,11 +547,18 @@ class Executor(RemoteExecutor):
             f"Transfer output files: {transfer_output_files}"
         )
 
-        # Warning for the absolute paths getting flatten after being sent to HTCondor
+        # Warning for the absolute paths getting flattened after being sent to HTCondor
         if job.resources.get("preserve_relative_paths", True):
             abs_paths = [p for p in transfer_input_files if isabs(p)]
             if abs_paths:
-                self.logger.warning(f"Absolute paths will be flattened: {abs_paths}")
+                self.logger.warning(
+                    f"Input files contain absolute paths: {abs_paths}, "
+                    "which will be flattened to their basename on the EP. "
+                    "This can cause unexpected failures when "
+                    "preserve_relative_paths is True. "
+                    "Use relative paths in your Snakefile to preserve "
+                    "directory structure."
+                )
 
         return transfer_input_files, transfer_output_files
 


### PR DESCRIPTION
## Summary 
When `preserve_relative_paths=True` (the default), HTCondor silently flattens absolute paths to basenames, which causes paths to break on the Execution Point.

## Changes
- Added warning in `_get_files_for_transfer()` when absolute paths are detected with `preserve_relative_paths=True`
- Added unit test for the warning

Example warning output: 
```
Input files contain absolute paths: ['/home/user/data/input.csv '], which will be flattened to their basename on the EP. This can cause unexpected failures when preserve_relative_paths is True. Use relative paths in your Snakefile to preserve directory structure.
```


Closes #22 