### PR TITLE
Monitor jobs using job logs, not condor_history and schedd

### DIFF
--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
-from typing import List, Generator, Optional
+from enum import Enum
+from typing import List, Generator, Optional, Dict
+import time
 from snakemake_interface_executor_plugins.executors.base import SubmittedJobInfo
 from snakemake_interface_executor_plugins.executors.remote import RemoteExecutor
 from snakemake_interface_executor_plugins.settings import (
@@ -12,11 +14,41 @@ from snakemake_interface_executor_plugins.jobs import (
 from snakemake_interface_common.exceptions import WorkflowError  # noqa
 
 import htcondor2 as htcondor
+from htcondor2 import JobEventLog, JobEventType
 import traceback
 from os.path import join, isabs, relpath, normpath, exists
 from os import makedirs, sep
 import re
 import sys
+
+
+class JobStatus(Enum):
+    """Enumeration of possible job statuses.
+
+    This enum provides type-safe status values and human-readable display names.
+    """
+
+    PENDING = "pending"
+    IDLE = "idle"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    HELD = "held"
+    REMOVED = "removed"
+    TRANSFERRING = "transferring"
+    SUSPENDED = "suspended"
+
+    @property
+    def display_name(self) -> str:
+        """Return a human-readable display name for the status."""
+        return self.value.capitalize()
+
+    def is_terminal(self) -> bool:
+        """Return True if this is a terminal state (job won't change further)."""
+        return self in (JobStatus.COMPLETED, JobStatus.REMOVED)
+
+
+# Default timeout for held jobs before treating them as failed (4 hours in seconds)
+DEFAULT_HELD_TIMEOUT_SECONDS = 4 * 60 * 60
 
 
 def is_shared_fs(in_path, shared_prefixes) -> bool:
@@ -53,6 +85,16 @@ class ExecutorSettings(ExecutorSettingsBase):
             "(e.g., '/staging,/shared'). Files under these paths are accessed directly "
             "without HTCondor transfer. Use with --shared-fs-usage none when only specific "
             "paths (not all I/O) are shared.",
+            "required": False,
+        },
+    )
+    held_timeout: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "Timeout in seconds for held jobs before treating them as failed. "
+            "This allows time for manual intervention (e.g., condor_release) before "
+            "the workflow fails. Default is 4 hours (14400 seconds). Set to 0 to "
+            "fail immediately when a job is held.",
             "required": False,
         },
     )
@@ -113,6 +155,32 @@ class Executor(RemoteExecutor):
         # Validate configuration and provide helpful guidance
         if self.shared_fs_prefixes:
             self._validate_shared_fs_configuration()
+
+        # Dictionary to track JobEventLog readers for each submitted job.
+        # Key: external_jobid (ClusterId), Value: JobEventLog reader
+        # This approach avoids expensive schedd queries by reading local log files,
+        # similar to how DAGMan and condor_watch_q operate.
+        self._job_event_logs: Dict[int, JobEventLog] = {}
+
+        # Dictionary to track the latest known state for each job.
+        # Key: external_jobid (ClusterId), Value: dict with current state info
+        # This is essential because JobEventLog readers maintain their position -
+        # once all events are read, subsequent reads return nothing. We track
+        # the last known state so we can return it when there are no new events.
+        self._job_current_states: Dict[int, dict] = {}
+
+        # Held job timeout - allows time for manual intervention before failing
+        held_timeout_setting = self.workflow.executor_settings.held_timeout
+        self._held_timeout = (
+            held_timeout_setting
+            if held_timeout_setting is not None
+            else DEFAULT_HELD_TIMEOUT_SECONDS
+        )
+        if self._held_timeout > 0:
+            self.logger.debug(
+                f"Held job timeout set to {self._held_timeout} seconds "
+                f"({self._held_timeout / 3600:.1f} hours)"
+            )
 
     def _validate_shared_fs_configuration(self):
         """Validate and warn about potentially confusing shared FS configuration."""
@@ -974,128 +1042,383 @@ class Executor(RemoteExecutor):
             f"in {self.jobDir}/{submit_result.cluster()}.log"
         )
 
+        # Initialize the JobEventLog reader for this job.
+        # We do this at submission time so the reader is ready when we start checking.
+        cluster_id = submit_result.cluster()
+        log_path = join(self.jobDir, f"{cluster_id}.log")
+        try:
+            self._job_event_logs[cluster_id] = JobEventLog(log_path)
+            self.logger.debug(
+                f"Initialized JobEventLog reader for cluster {cluster_id}"
+            )
+        except Exception as e:
+            self.logger.warning(
+                f"Could not initialize JobEventLog for cluster {cluster_id}: {e}. "
+                "Will retry on first status check."
+            )
+
         self.report_job_submission(
             SubmittedJobInfo(job=job, external_jobid=submit_result.cluster())
         )
 
+    def _get_job_event_log(self, cluster_id: int) -> Optional[JobEventLog]:
+        """
+        Get or create a JobEventLog reader for the given cluster ID.
+
+        This method lazily initializes log readers if they weren't created at
+        submission time (e.g., if the log file wasn't ready yet).
+
+        Args:
+            cluster_id: The HTCondor ClusterId for the job
+
+        Returns:
+            JobEventLog reader, or None if the log file doesn't exist yet
+        """
+        if cluster_id in self._job_event_logs:
+            return self._job_event_logs[cluster_id]
+
+        # Try to create the reader now
+        log_path = join(self.jobDir, f"{cluster_id}.log")
+        if exists(log_path):
+            try:
+                self._job_event_logs[cluster_id] = JobEventLog(log_path)
+                self.logger.debug(
+                    f"Lazily initialized JobEventLog reader for cluster {cluster_id}"
+                )
+                return self._job_event_logs[cluster_id]
+            except Exception as e:
+                self.logger.warning(
+                    f"Could not initialize JobEventLog for cluster {cluster_id}: {e}"
+                )
+                return None
+        else:
+            self.logger.debug(f"Log file not yet available for cluster {cluster_id}")
+            return None
+
+    def _cleanup_job_tracking(self, cluster_id: int) -> None:
+        """
+        Clean up tracking data structures for a completed/failed job.
+
+        This prevents memory growth over long-running workflows by removing
+        references to jobs that are no longer active.
+
+        Args:
+            cluster_id: The HTCondor ClusterId for the job
+        """
+        # Remove the JobEventLog reader (closes file handle)
+        if cluster_id in self._job_event_logs:
+            del self._job_event_logs[cluster_id]
+
+        # Remove cached job state
+        if cluster_id in self._job_current_states:
+            del self._job_current_states[cluster_id]
+
+    def _read_job_events(self, cluster_id: int) -> Optional[dict]:
+        """
+        Read all available events from a job's log file and determine its current state.
+
+        This method reads events non-blockingly (stop_after=0) and updates the
+        tracked state for this job. Since JobEventLog readers maintain their position,
+        subsequent calls only read NEW events and we must track state across calls.
+
+        The key insight is that HTCondor log files are append-only and contain
+        the complete history of a job. We read all new events since our last
+        read and update the tracked state.
+
+        Args:
+            cluster_id: The HTCondor ClusterId for the job
+
+        Returns:
+            A dict with job state info:
+            - 'status': A JobStatus enum value
+            - 'exit_code': Exit code if completed (may be None)
+            - 'exit_by_signal': Whether job exited by signal
+            - 'exit_signal': Signal number if exited by signal
+            - 'hold_reason': Reason string if held
+            - 'held_since': Timestamp when job entered held state (if held)
+            Or None if we couldn't read the log
+        """
+        event_log = self._get_job_event_log(cluster_id)
+        if event_log is None:
+            # Can't read log yet - return existing state if we have one, else None
+            return self._job_current_states.get(cluster_id)
+
+        # Get or initialize the current state for this job
+        # We persist state across calls because JobEventLog readers maintain position
+        if cluster_id not in self._job_current_states:
+            self._job_current_states[cluster_id] = {
+                "status": JobStatus.PENDING,
+                "exit_code": None,
+                "exit_by_signal": False,
+                "exit_signal": None,
+                "hold_reason": None,
+                "held_since": None,
+            }
+
+        current_state = self._job_current_states[cluster_id]
+
+        # If job already reached a true terminal state, return cached result
+        # Note: 'held' is NOT terminal - job may be released and continue
+        if current_state["status"].is_terminal():
+            return current_state
+
+        try:
+            # Read all available NEW events without blocking (stop_after=0)
+            # This returns immediately with events since our last read
+            events_read = 0
+            for event in event_log.events(stop_after=0):
+                events_read += 1
+                event_type = event.type
+
+                if event_type == JobEventType.SUBMIT:
+                    current_state["status"] = JobStatus.IDLE
+
+                elif event_type == JobEventType.EXECUTE:
+                    current_state["status"] = JobStatus.RUNNING
+
+                elif event_type == JobEventType.JOB_EVICTED:
+                    # Job was evicted but may be rescheduled
+                    current_state["status"] = JobStatus.IDLE
+
+                elif event_type == JobEventType.JOB_SUSPENDED:
+                    current_state["status"] = JobStatus.SUSPENDED
+
+                elif event_type == JobEventType.JOB_UNSUSPENDED:
+                    current_state["status"] = JobStatus.RUNNING
+
+                elif event_type == JobEventType.IMAGE_SIZE:
+                    # Just an update, job is still running - don't change status
+                    pass
+
+                elif event_type == JobEventType.FILE_TRANSFER:
+                    # File transfer in progress - could be input (before run) or output (after)
+                    # Don't override 'running' status if already running
+                    if current_state["status"] != JobStatus.RUNNING:
+                        current_state["status"] = JobStatus.TRANSFERRING
+
+                elif event_type == JobEventType.JOB_HELD:
+                    current_state["status"] = JobStatus.HELD
+                    # Try to get hold reason from event
+                    current_state["hold_reason"] = event.get(
+                        "HoldReason", "Unknown reason"
+                    )
+                    # Record when the job was held for timeout tracking
+                    current_state["held_since"] = time.time()
+
+                elif event_type == JobEventType.JOB_RELEASED:
+                    # Job was released from hold, back to idle
+                    current_state["status"] = JobStatus.IDLE
+                    current_state["hold_reason"] = None
+                    current_state["held_since"] = None
+
+                elif event_type == JobEventType.JOB_TERMINATED:
+                    current_state["status"] = JobStatus.COMPLETED
+                    # Extract exit information from the event
+                    current_state["exit_code"] = event.get("ReturnValue", None)
+                    # Check if terminated by signal - look for TerminatedNormally=False
+                    terminated_normally = event.get("TerminatedNormally", True)
+                    current_state["exit_by_signal"] = not terminated_normally
+                    if current_state["exit_by_signal"]:
+                        current_state["exit_signal"] = event.get(
+                            "TerminatedBySignal", None
+                        )
+
+                elif event_type == JobEventType.JOB_ABORTED:
+                    current_state["status"] = JobStatus.REMOVED
+
+                elif event_type == JobEventType.JOB_RECONNECT_FAILED:
+                    # Shadow couldn't reconnect, job will be rescheduled
+                    current_state["status"] = JobStatus.IDLE
+
+                elif event_type == JobEventType.SHADOW_EXCEPTION:
+                    # Shadow had an exception, job may be rescheduled
+                    current_state["status"] = JobStatus.IDLE
+
+                elif event_type == JobEventType.JOB_DISCONNECTED:
+                    # Starter and shadow are disconnected, may reconnect
+                    pass  # Keep current status
+
+                elif event_type == JobEventType.JOB_RECONNECTED:
+                    # Reconnected after disconnect
+                    current_state["status"] = JobStatus.RUNNING
+
+                # Note: Other event types (ATTRIBUTE_UPDATE, CHECKPOINTED, etc.)
+                # don't change the fundamental job state, so we ignore them.
+
+            self.logger.debug(
+                f"Read {events_read} new events for cluster {cluster_id}, "
+                f"status: {current_state['status'].display_name}"
+            )
+
+        except Exception as e:
+            self.logger.warning(
+                f"Error reading job events for cluster {cluster_id}: {e}"
+            )
+            # Return the last known state rather than None
+            return current_state
+
+        return current_state
+
     async def check_active_jobs(
         self, active_jobs: List[SubmittedJobInfo]
     ) -> Generator[SubmittedJobInfo, None, None]:
-        # Check the status of active jobs.
+        """
+        Check the status of active jobs by reading their HTCondor log files.
 
+        This implementation avoids expensive schedd queries by reading the local
+        job event log files, similar to how DAGMan and condor_watch_q operate.
+        This is the recommended approach for monitoring many concurrent jobs
+        without putting load on the schedd.
+
+        The method reads all new events from each job's log file and determines
+        the current state. Terminal states (completed, removed) are cached
+        to avoid re-reading finished jobs. Held jobs are monitored with a timeout -
+        they remain active to allow for manual release, but will fail after the
+        configured timeout period.
+        """
         for current_job in active_jobs:
-            async with self.status_rate_limiter:
-                # Get the status of the job from HTCondor
-                try:
-                    schedd = htcondor.Schedd()
-                    job_status = schedd.query(
-                        constraint=f"ClusterId == {current_job.external_jobid}",
-                        projection=[
-                            "ExitBySignal",
-                            "ExitCode",
-                            "ExitSignal",
-                            "JobStatus",
-                        ],
+            cluster_id = current_job.external_jobid
+
+            try:
+                job_state = self._read_job_events(cluster_id)
+
+                if job_state is None:
+                    # Couldn't read log yet, assume job is still pending
+                    self.logger.debug(
+                        f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                        f"{cluster_id}: log not available yet, assuming still active"
                     )
-                    # Job is not running anymore, look
-                    if not job_status:
-                        job_status = schedd.history(
-                            constraint=f"ClusterId == {current_job.external_jobid}",
-                            projection=[
-                                "ExitBySignal",
-                                "ExitCode",
-                                "ExitSignal",
-                                "JobStatus",
-                            ],
-                        )
-                        #  Storing the one event from history list
-                        if job_status and len(job_status) >= 1:
-                            job_status = [job_status[0]]
-                        else:
-                            raise ValueError(
-                                f"No job status found in history for HTCondor job with Cluster ID {current_job.external_jobid}."  # noqa
-                            )
-                except Exception as e:
-                    self.logger.warning(f"Failed to retrieve HTCondor job status: {e}")
-                    # Assuming the job is still running and retry next time
                     yield current_job
+                    continue
+
+                status = job_state["status"]
                 self.logger.debug(
                     f"Job {current_job.job.jobid} with HTCondor Cluster ID "
-                    f"{current_job.external_jobid} has status: {job_status}"
+                    f"{cluster_id} has status: {status.display_name}"
                 )
 
-                # Overview of HTCondor job status:
-                status_dict = {
-                    "1": "Idle",
-                    "2": "Running",
-                    "3": "Removed",
-                    "4": "Completed",
-                    "5": "Held",
-                    "6": "Transferring Output",
-                    "7": "Suspended",
-                }
-
-                # Running/idle jobs
-                if job_status[0]["JobStatus"] in [1, 2, 6, 7]:
-                    if job_status[0]["JobStatus"] in [7]:
-                        self.logger.warning(
-                            f"Job {current_job.job.jobid} with "
-                            "HTCondor Cluster ID "
-                            f"{current_job.external_jobid} is suspended."
-                        )
+                # Handle different states
+                if status in (
+                    JobStatus.PENDING,
+                    JobStatus.IDLE,
+                    JobStatus.RUNNING,
+                    JobStatus.TRANSFERRING,
+                ):
+                    # Job is still active
                     yield current_job
-                # Completed jobs
-                elif job_status[0]["JobStatus"] in [4]:
-                    self.logger.debug(
-                        f"Check whether Job {current_job.job.jobid} with "
-                        "HTCondor Cluster ID "
-                        f"{current_job.external_jobid} was successful."
+
+                elif status == JobStatus.SUSPENDED:
+                    self.logger.warning(
+                        f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                        f"{cluster_id} is suspended."
                     )
-                    # Check ExitCode
-                    if job_status[0]["ExitCode"] == 0:
-                        # Job was successful
+                    yield current_job
+
+                elif status == JobStatus.COMPLETED:
+                    exit_code = job_state.get("exit_code")
+                    exit_by_signal = job_state.get("exit_by_signal", False)
+
+                    if exit_by_signal:
+                        signal = job_state.get("exit_signal", "unknown")
                         self.logger.debug(
-                            f"Report Job {current_job.job.jobid} with "
-                            "HTCondor Cluster ID "
-                            f"{current_job.external_jobid} success"
+                            f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                            f"{cluster_id} terminated by signal {signal}"
+                        )
+                        self.report_job_error(
+                            current_job,
+                            msg=f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                            f"{cluster_id} was terminated by signal {signal}.",
+                        )
+                    elif exit_code == 0:
+                        self.logger.debug(
+                            f"Report Job {current_job.job.jobid} with HTCondor Cluster ID "
+                            f"{cluster_id} success"
                         )
                         self.logger.info(
-                            f"Job {current_job.job.jobid} with "
-                            "HTCondor Cluster ID "
-                            f"{current_job.external_jobid} was successful."
+                            f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                            f"{cluster_id} was successful."
                         )
                         self.report_job_success(current_job)
                     else:
                         self.logger.debug(
-                            f"Report Job {current_job.job.jobid} with "
-                            "HTCondor Cluster ID "
-                            f"{current_job.external_jobid} error"
+                            f"Report Job {current_job.job.jobid} with HTCondor Cluster ID "
+                            f"{cluster_id} error"
                         )
                         self.report_job_error(
                             current_job,
-                            msg=f"Job {current_job.job.jobid} with "
-                            "HTCondor Cluster ID "
-                            f"{current_job.external_jobid} has "
-                            f" status {status_dict[str(job_status[0]['JobStatus'])]}, "
-                            "but failed with "
-                            f"ExitCode {job_status[0]['ExitCode']}.",
+                            msg=f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                            f"{cluster_id} completed but failed with ExitCode {exit_code}.",
                         )
-                # Errored jobs
-                elif job_status[0]["JobStatus"] in [3, 5]:
+
+                    # Clean up tracking for this job
+                    self._cleanup_job_tracking(cluster_id)
+
+                elif status == JobStatus.HELD:
+                    hold_reason = job_state.get("hold_reason", "Unknown reason")
+                    held_since = job_state.get("held_since")
+
+                    # Check if hold timeout has been exceeded
+                    if self._held_timeout == 0:
+                        # Timeout of 0 means fail immediately
+                        self.report_job_error(
+                            current_job,
+                            msg=f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                            f"{cluster_id} is held: {hold_reason}",
+                        )
+                        self._cleanup_job_tracking(cluster_id)
+                    elif held_since is not None:
+                        elapsed = time.time() - held_since
+                        if elapsed >= self._held_timeout:
+                            # Timeout exceeded - treat as terminal failure
+                            timeout_hours = self._held_timeout / 3600
+                            self.report_job_error(
+                                current_job,
+                                msg=f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                                f"{cluster_id} has been held for {elapsed / 3600:.1f} hours "
+                                f"(timeout: {timeout_hours:.1f} hours). Hold reason: {hold_reason}",
+                            )
+                            self._cleanup_job_tracking(cluster_id)
+                        else:
+                            # Still within timeout - keep monitoring
+                            remaining = self._held_timeout - elapsed
+                            self.logger.info(
+                                f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                                f"{cluster_id} is held: {hold_reason}. "
+                                f"Will fail in {remaining / 60:.0f} minutes if not released."
+                            )
+                            yield current_job
+                    else:
+                        # No held_since timestamp (shouldn't happen) - keep monitoring
+                        self.logger.warning(
+                            f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                            f"{cluster_id} is held but missing timestamp: {hold_reason}"
+                        )
+                        yield current_job
+
+                elif status == JobStatus.REMOVED:
                     self.report_job_error(
                         current_job,
-                        msg=f"Job {current_job.job.jobid} with "
-                        "HTCondor Cluster ID "
-                        f"{current_job.external_jobid} has "
-                        f"status {status_dict[str(job_status[0]['JobStatus'])]}.",
+                        msg=f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                        f"{cluster_id} was removed/aborted.",
                     )
+                    # Clean up tracking for this job
+                    self._cleanup_job_tracking(cluster_id)
+
                 else:
-                    raise WorkflowError(
-                        f"Job {current_job.job.jobid} with "
-                        "HTCondor Cluster ID "
-                        f"{current_job.external_jobid} has "
-                        f"unknown HTCondor job status: {job_status[0]['JobStatus']}"
+                    # Unknown status - keep monitoring
+                    self.logger.warning(
+                        f"Job {current_job.job.jobid} with HTCondor Cluster ID "
+                        f"{cluster_id} has unexpected status: {status}"
                     )
+                    yield current_job
+
+            except Exception as e:
+                self.logger.warning(
+                    f"Error checking job {current_job.job.jobid} with "
+                    f"HTCondor Cluster ID {cluster_id}: {e}"
+                )
+                # Assume job is still running and retry next time
+                yield current_job
 
     def cancel_jobs(self, active_jobs: List[SubmittedJobInfo]):
         # Cancel all active jobs.

--- a/tests/test_job_event_log.py
+++ b/tests/test_job_event_log.py
@@ -8,1465 +8,660 @@ and interprets job states, replacing the previous schedd query-based approach.
 import pytest
 import time
 from unittest.mock import Mock
+from htcondor2 import JobEventType
 from snakemake_executor_plugin_htcondor import Executor, JobStatus, JobState
 
 
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
 def make_event(event_type, **kwargs):
-    """
-    Helper to create a mock event with the given type.
-
-    This is a module-level helper used by all test classes to avoid duplication.
-
-    Args:
-        event_type: The JobEventType for this event
-        **kwargs: Additional key-value pairs to return from event.get()
-
-    Returns:
-        A Mock event object with the specified type and data
-    """
+    """Create a mock HTCondor event with the given type and attributes."""
     event = Mock()
     event.type = event_type
     event.get = Mock(side_effect=lambda k, d=None: kwargs.get(k, d))
     return event
 
 
-class TestJobEventLogStateTracking:
-    """Tests for job state tracking across multiple check cycles."""
+def make_mock_executor(**extra_attrs):
+    """
+    Create a mock executor with the core methods bound.
 
-    def test_state_persists_across_reads(self):
-        """
-        Verify that job state is correctly tracked across multiple
-        check cycles when no new events have occurred.
+    Additional attributes (e.g. _held_timeout) can be passed as kwargs.
+    """
+    executor = Mock(spec=Executor)
+    executor.logger = Mock()
+    executor._job_event_logs = {}
+    executor._job_current_states = {}
+    executor._log_missing_counts = {}
+    executor.jobDir = "/tmp/test_htcondor"
 
-        This tests the core fix for the 'Unknown' status bug where
-        JobEventLog readers advance their position and return no
-        events on subsequent reads.
-        """
-        from htcondor2 import JobEventType
+    for method_name in (
+        "_read_job_events",
+        "_get_job_event_log",
+        "_cleanup_job_tracking",
+        "_try_read_job_log",
+        "_needs_fallback",
+        "_htcondor_status_to_job_status",
+        "_batch_query_schedd",
+        "_batch_query_history",
+    ):
+        method = getattr(Executor, method_name)
+        setattr(executor, method_name, method.__get__(executor, Executor))
 
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor.jobDir = "/tmp/test"
+    # Sensible defaults that individual tests can override
+    executor._held_timeout = 14400
+    executor._log_missing_threshold = 3
+    executor._workflow_start_time = int(time.time()) - 3600
 
-        # Bind methods
-        executor._read_job_events = Executor._read_job_events.__get__(
-            executor, Executor
-        )
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
-        )
+    for k, v in extra_attrs.items():
+        setattr(executor, k, v)
 
-        # Create a mock event log that returns events on first call, empty on second
-        mock_event_log = Mock()
-        call_count = [0]
-
-        def events_generator(stop_after=0):
-            call_count[0] += 1
-            if call_count[0] == 1:
-                # First call: return submit and execute events
-                return iter(
-                    [
-                        make_event(JobEventType.SUBMIT),
-                        make_event(JobEventType.EXECUTE),
-                    ]
-                )
-            else:
-                # Subsequent calls: no new events
-                return iter([])
-
-        mock_event_log.events = Mock(side_effect=events_generator)
-        executor._job_event_logs[12345] = mock_event_log
-
-        # First read
-        result1 = executor._read_job_events(12345)
-        assert result1.status == JobStatus.RUNNING
-
-        # Second read (no new events) - should return cached state
-        result2 = executor._read_job_events(12345)
-        assert result2.status == JobStatus.RUNNING
-
-    def test_cleanup_removes_tracking_data(self):
-        """Verify that job tracking data is cleaned up after job completes."""
-        executor = Mock(spec=Executor)
-        executor._job_event_logs = {12345: Mock()}
-        executor._job_current_states = {12345: JobState(status=JobStatus.COMPLETED)}
-        executor._log_missing_counts = {12345: 2}
-        executor.logger = Mock()
-
-        # Bind the cleanup method
-        executor._cleanup_job_tracking = Executor._cleanup_job_tracking.__get__(
-            executor, Executor
-        )
-
-        executor._cleanup_job_tracking(12345)
-
-        assert 12345 not in executor._job_event_logs
-        assert 12345 not in executor._job_current_states
-        assert 12345 not in executor._log_missing_counts
+    return executor
 
 
-class TestJobEventTypes:
-    """Tests for handling different HTCondor job event types."""
+def _setup_event_log(executor, cluster_id, events):
+    """Attach a mock event log returning *events* to *executor*."""
+    mock_log = Mock()
+    mock_log.events = Mock(return_value=iter(events))
+    executor._job_event_logs[cluster_id] = mock_log
+
+
+# ---------------------------------------------------------------------------
+# Event-type → status mapping
+# ---------------------------------------------------------------------------
+class TestEventToStatusMapping:
+    """Verify that each HTCondor event type produces the correct JobStatus."""
 
     @pytest.fixture
-    def mock_executor(self):
-        """Create a mock executor with the event reading methods bound."""
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor.jobDir = "/tmp/test_htcondor"
+    def executor(self):
+        return make_mock_executor()
 
-        # Bind methods
-        executor._read_job_events = Executor._read_job_events.__get__(
-            executor, Executor
+    # -- simple single-event tests -----------------------------------------
+
+    def test_submit_sets_idle(self, executor):
+        _setup_event_log(executor, 1, [make_event(JobEventType.SUBMIT)])
+        assert executor._read_job_events(1).status == JobStatus.IDLE
+
+    def test_execute_sets_running(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+            ],
         )
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
+        assert executor._read_job_events(1).status == JobStatus.RUNNING
+
+    def test_evicted_sets_idle(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(JobEventType.JOB_EVICTED),
+            ],
         )
-        executor._cleanup_job_tracking = Executor._cleanup_job_tracking.__get__(
-            executor, Executor
+        assert executor._read_job_events(1).status == JobStatus.IDLE
+
+    def test_suspended_sets_suspended(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(JobEventType.JOB_SUSPENDED),
+            ],
         )
+        assert executor._read_job_events(1).status == JobStatus.SUSPENDED
 
-        return executor
-
-    def test_submit_event_sets_idle(self, mock_executor):
-        """SUBMIT event (type 0) should set status to IDLE."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter([make_event(JobEventType.SUBMIT)])
+    def test_unsuspended_sets_running(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(JobEventType.JOB_SUSPENDED),
+                make_event(JobEventType.JOB_UNSUSPENDED),
+            ],
         )
+        assert executor._read_job_events(1).status == JobStatus.RUNNING
 
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        assert result.status == JobStatus.IDLE
-
-    def test_execute_event_sets_running(self, mock_executor):
-        """EXECUTE event (type 1) should set status to RUNNING."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                ]
-            )
+    def test_shadow_exception_sets_idle(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(JobEventType.SHADOW_EXCEPTION),
+            ],
         )
+        assert executor._read_job_events(1).status == JobStatus.IDLE
 
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        assert result.status == JobStatus.RUNNING
-
-    def test_terminated_event_sets_completed(self, mock_executor):
-        """JOB_TERMINATED event (type 5) should set status to COMPLETED."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(
-                        JobEventType.JOB_TERMINATED,
-                        ReturnValue=0,
-                        TerminatedNormally=True,
-                    ),
-                ]
-            )
+    def test_reconnect_failed_sets_idle(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(JobEventType.JOB_RECONNECT_FAILED),
+            ],
         )
+        assert executor._read_job_events(1).status == JobStatus.IDLE
 
-        mock_executor._job_event_logs[12345] = mock_event_log
+    def test_reconnected_sets_running(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(JobEventType.JOB_DISCONNECTED),
+                make_event(JobEventType.JOB_RECONNECTED),
+            ],
+        )
+        assert executor._read_job_events(1).status == JobStatus.RUNNING
 
-        result = mock_executor._read_job_events(12345)
+    def test_aborted_sets_removed(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.JOB_ABORTED),
+            ],
+        )
+        assert executor._read_job_events(1).status == JobStatus.REMOVED
 
-        assert result is not None
+    def test_file_transfer_sets_transferring_when_not_running(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.FILE_TRANSFER),
+            ],
+        )
+        assert executor._read_job_events(1).status == JobStatus.TRANSFERRING
+
+    def test_file_transfer_does_not_override_running(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(JobEventType.FILE_TRANSFER),
+            ],
+        )
+        assert executor._read_job_events(1).status == JobStatus.RUNNING
+
+    def test_image_size_does_not_change_status(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(JobEventType.IMAGE_SIZE),
+            ],
+        )
+        assert executor._read_job_events(1).status == JobStatus.RUNNING
+
+    # -- terminated events with metadata -----------------------------------
+
+    def test_terminated_normal_exit_zero(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(
+                    JobEventType.JOB_TERMINATED, ReturnValue=0, TerminatedNormally=True
+                ),
+            ],
+        )
+        result = executor._read_job_events(1)
         assert result.status == JobStatus.COMPLETED
         assert result.exit_code == 0
         assert result.exit_by_signal is False
 
-    def test_terminated_with_nonzero_exit(self, mock_executor):
-        """JOB_TERMINATED with non-zero exit code should be captured."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(
-                        JobEventType.JOB_TERMINATED,
-                        ReturnValue=42,
-                        TerminatedNormally=True,
-                    ),
-                ]
-            )
+    def test_terminated_nonzero_exit(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(
+                    JobEventType.JOB_TERMINATED, ReturnValue=42, TerminatedNormally=True
+                ),
+            ],
         )
-
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
+        result = executor._read_job_events(1)
         assert result.status == JobStatus.COMPLETED
         assert result.exit_code == 42
 
-    def test_held_event_sets_held_with_timestamp(self, mock_executor):
-        """JOB_HELD event (type 12) should set status to HELD and record timestamp."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(
-                        JobEventType.JOB_HELD, HoldReason="Job exceeded memory limit"
-                    ),
-                ]
-            )
+    def test_terminated_by_signal(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(
+                    JobEventType.JOB_TERMINATED,
+                    ReturnValue=None,
+                    TerminatedNormally=False,
+                    TerminatedBySignal=9,
+                ),
+            ],
         )
+        result = executor._read_job_events(1)
+        assert result.status == JobStatus.COMPLETED
+        assert result.exit_by_signal is True
+        assert result.exit_signal == 9
 
-        mock_executor._job_event_logs[12345] = mock_event_log
+    # -- held / released ---------------------------------------------------
 
-        before_time = time.time()
-        result = mock_executor._read_job_events(12345)
-        after_time = time.time()
+    def test_held_event_records_reason_and_timestamp(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(
+                    JobEventType.JOB_HELD, HoldReason="Job exceeded memory limit"
+                ),
+            ],
+        )
+        before = time.time()
+        result = executor._read_job_events(1)
+        after = time.time()
 
-        assert result is not None
         assert result.status == JobStatus.HELD
         assert result.hold_reason == "Job exceeded memory limit"
-        # Verify held_since is set to approximately the current time
-        assert result.held_since is not None
-        assert before_time <= result.held_since <= after_time
+        assert before <= result.held_since <= after
 
-    def test_aborted_event_sets_removed(self, mock_executor):
-        """JOB_ABORTED event (type 9) should set status to REMOVED."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.JOB_ABORTED),
-                ]
-            )
+    def test_released_clears_hold_state(self, executor):
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.JOB_HELD, HoldReason="test"),
+                make_event(JobEventType.JOB_RELEASED),
+            ],
         )
-
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        assert result.status == JobStatus.REMOVED
-
-    def test_evicted_event_sets_idle(self, mock_executor):
-        """JOB_EVICTED event should set status back to IDLE."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(JobEventType.JOB_EVICTED),
-                ]
-            )
-        )
-
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
+        result = executor._read_job_events(1)
         assert result.status == JobStatus.IDLE
-
-    def test_suspended_event_sets_suspended(self, mock_executor):
-        """JOB_SUSPENDED event should set status to SUSPENDED."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(JobEventType.JOB_SUSPENDED),
-                ]
-            )
-        )
-
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        assert result.status == JobStatus.SUSPENDED
-
-    def test_unsuspended_event_sets_running(self, mock_executor):
-        """JOB_UNSUSPENDED event should set status back to RUNNING."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(JobEventType.JOB_SUSPENDED),
-                    make_event(JobEventType.JOB_UNSUSPENDED),
-                ]
-            )
-        )
-
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        assert result.status == JobStatus.RUNNING
-
-    def test_released_event_clears_held_state(self, mock_executor):
-        """JOB_RELEASED event should set status back to IDLE and clear held_since."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.JOB_HELD, HoldReason="Test hold reason"),
-                    make_event(JobEventType.JOB_RELEASED),
-                ]
-            )
-        )
-
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        assert result.status == JobStatus.IDLE
-        # hold_reason and held_since should be cleared after release
         assert result.hold_reason is None
         assert result.held_since is None
 
-    def test_file_transfer_event_sets_transferring(self, mock_executor):
-        """FILE_TRANSFER event should set status to TRANSFERRING when not running."""
-        from htcondor2 import JobEventType
 
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.FILE_TRANSFER),
-                ]
-            )
-        )
+# ---------------------------------------------------------------------------
+# State persistence across reads (core "Unknown status" bug fix)
+# ---------------------------------------------------------------------------
+class TestStatePersistence:
+    """State must survive across read cycles when no new events appear."""
 
-        mock_executor._job_event_logs[12345] = mock_event_log
+    def test_cached_state_returned_on_empty_read(self):
+        """Core regression test for the 'Unknown status' bug: JobEventLog
+        readers advance their position and return no events on subsequent
+        reads, so the cached state must be returned instead of PENDING."""
+        executor = make_mock_executor()
 
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        assert result.status == JobStatus.TRANSFERRING
-
-    def test_file_transfer_does_not_override_running(self, mock_executor):
-        """FILE_TRANSFER event should not override RUNNING status."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),  # Now running
-                    make_event(JobEventType.FILE_TRANSFER),  # Output transfer
-                ]
-            )
-        )
-
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        # Should still be RUNNING, not TRANSFERRING
-        assert result.status == JobStatus.RUNNING
-
-    def test_image_size_event_does_not_change_status(self, mock_executor):
-        """IMAGE_SIZE event should not change the job status."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(JobEventType.IMAGE_SIZE),
-                ]
-            )
-        )
-
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        assert result.status == JobStatus.RUNNING  # Still running
-
-    def test_shadow_exception_sets_idle(self, mock_executor):
-        """SHADOW_EXCEPTION event should set status to IDLE (for reschedule)."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(JobEventType.SHADOW_EXCEPTION),
-                ]
-            )
-        )
-
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        assert result.status == JobStatus.IDLE
-
-    def test_reconnect_failed_sets_idle(self, mock_executor):
-        """JOB_RECONNECT_FAILED event should set status to IDLE."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(JobEventType.JOB_RECONNECT_FAILED),
-                ]
-            )
-        )
-
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        assert result.status == JobStatus.IDLE
-
-    def test_reconnected_sets_running(self, mock_executor):
-        """JOB_RECONNECTED event should set status to RUNNING."""
-        from htcondor2 import JobEventType
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(JobEventType.JOB_DISCONNECTED),
-                    make_event(JobEventType.JOB_RECONNECTED),
-                ]
-            )
-        )
-
-        mock_executor._job_event_logs[12345] = mock_event_log
-
-        result = mock_executor._read_job_events(12345)
-
-        assert result is not None
-        assert result.status == JobStatus.RUNNING
-
-
-class TestStatePersistenceAcrossReads:
-    """
-    Tests verifying that state persists correctly when no new events are available.
-
-    This specifically tests the fix for the 'Unknown' status bug.
-    """
-
-    def test_second_read_returns_cached_state(self):
-        """
-        Verify that the second read (with no new events) returns
-        the last known state, not 'pending'/'unknown'.
-        """
-        from htcondor2 import JobEventType
-
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor.jobDir = "/tmp/test"
-
-        # Bind methods
-        executor._read_job_events = Executor._read_job_events.__get__(
-            executor, Executor
-        )
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
-        )
-
-        # Create a mock event log that returns events on first call, empty on second
-        mock_event_log = Mock()
         call_count = [0]
 
-        def events_generator(stop_after=0):
+        def events_gen(stop_after=0):
             call_count[0] += 1
             if call_count[0] == 1:
-                # First call: return submit and execute events
                 return iter(
                     [
                         make_event(JobEventType.SUBMIT),
                         make_event(JobEventType.EXECUTE),
                     ]
                 )
-            else:
-                # Subsequent calls: no new events
-                return iter([])
+            return iter([])
 
-        mock_event_log.events = Mock(side_effect=events_generator)
-        executor._job_event_logs[12345] = mock_event_log
+        mock_log = Mock()
+        mock_log.events = Mock(side_effect=events_gen)
+        executor._job_event_logs[1] = mock_log
 
-        # First read
-        result1 = executor._read_job_events(12345)
-        assert result1.status == JobStatus.RUNNING
+        assert executor._read_job_events(1).status == JobStatus.RUNNING
+        assert executor._read_job_events(1).status == JobStatus.RUNNING
 
-        # Second read (no new events)
-        result2 = executor._read_job_events(12345)
-        assert (
-            result2.status == JobStatus.RUNNING
-        )  # Should still be RUNNING, not PENDING
-
-    def test_terminal_state_cached_and_returned(self):
-        """
-        Verify that terminal states (completed, removed) are
-        returned without re-reading the log.
-        """
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor.jobDir = "/tmp/test"
-
-        # Bind methods
-        executor._read_job_events = Executor._read_job_events.__get__(
-            executor, Executor
+    def test_terminal_state_returned_without_rereading_log(self):
+        """Terminal states (COMPLETED, REMOVED) short-circuit: no event log
+        access is needed."""
+        executor = make_mock_executor()
+        executor._job_current_states[1] = JobState(
+            status=JobStatus.COMPLETED,
+            exit_code=0,
         )
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
-        )
-
-        # Pre-populate with a terminal state
-        executor._job_current_states[12345] = JobState(
-            status=JobStatus.COMPLETED, exit_code=0
-        )
-
-        # Should return cached state without reading log
-        result = executor._read_job_events(12345)
-
+        result = executor._read_job_events(1)
         assert result.status == JobStatus.COMPLETED
         assert result.exit_code == 0
 
     def test_held_state_is_not_terminal(self):
-        """
-        Verify that held state is NOT cached as terminal - it should
-        continue to read events in case job is released.
-        """
-        from htcondor2 import JobEventType
-
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor.jobDir = "/tmp/test"
-
-        # Bind methods
-        executor._read_job_events = Executor._read_job_events.__get__(
-            executor, Executor
-        )
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
-        )
-
-        # Pre-populate with a held state
-        executor._job_current_states[12345] = JobState(
+        """Held jobs must keep reading events — they may be released."""
+        executor = make_mock_executor()
+        executor._job_current_states[1] = JobState(
             status=JobStatus.HELD,
-            hold_reason="Test reason",
-            held_since=time.time() - 60,  # Held for 1 minute
+            hold_reason="test",
+            held_since=time.time() - 60,
         )
+        _setup_event_log(executor, 1, [make_event(JobEventType.JOB_RELEASED)])
 
-        # Create a mock event log that returns a RELEASED event
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.JOB_RELEASED),
-                ]
-            )
-        )
-        executor._job_event_logs[12345] = mock_event_log
-
-        # Read should process the release event
-        result = executor._read_job_events(12345)
-
-        # Job should now be IDLE, not still HELD
+        result = executor._read_job_events(1)
         assert result.status == JobStatus.IDLE
         assert result.hold_reason is None
-        assert result.held_since is None
 
 
-class TestLogFileInitialization:
-    """Tests for lazy log file initialization."""
+# ---------------------------------------------------------------------------
+# Realistic multi-event lifecycle scenarios
+# ---------------------------------------------------------------------------
+class TestJobLifecycleScenarios:
+    """End-to-end event sequences representing real HTCondor job lifecycles."""
 
-    def test_lazy_initialization_when_file_not_ready(self):
-        """Test that missing log files don't cause errors."""
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor.jobDir = "/nonexistent/path"
+    @pytest.fixture
+    def executor(self):
+        return make_mock_executor()
 
-        # Bind method
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
+    def test_preemption_and_reschedule(self, executor):
+        """SUBMIT → EXECUTE → EVICTED → EXECUTE → TERMINATED"""
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(JobEventType.JOB_EVICTED),
+                make_event(JobEventType.EXECUTE),
+                make_event(
+                    JobEventType.JOB_TERMINATED, ReturnValue=0, TerminatedNormally=True
+                ),
+            ],
         )
+        result = executor._read_job_events(1)
+        assert result.status == JobStatus.COMPLETED
+        assert result.exit_code == 0
 
-        # Should return None, not raise
-        result = executor._get_job_event_log(99999)
-        assert result is None
-
-    def test_returns_existing_reader(self):
-        """Test that existing readers are returned without creating new ones."""
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor.jobDir = "/tmp/test"
-
-        existing_reader = Mock()
-        executor._job_event_logs = {12345: existing_reader}
-
-        # Bind method
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
+    def test_hold_release_and_complete(self, executor):
+        """SUBMIT → EXECUTE → HELD → RELEASED → EXECUTE → TERMINATED"""
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(JobEventType.JOB_HELD, HoldReason="Policy violation"),
+                make_event(JobEventType.JOB_RELEASED),
+                make_event(JobEventType.EXECUTE),
+                make_event(
+                    JobEventType.JOB_TERMINATED, ReturnValue=0, TerminatedNormally=True
+                ),
+            ],
         )
+        result = executor._read_job_events(1)
+        assert result.status == JobStatus.COMPLETED
+        assert result.hold_reason is None
 
-        result = executor._get_job_event_log(12345)
-        assert result is existing_reader
-
-
-class TestErrorHandling:
-    """Tests for error handling in event reading."""
-
-    def test_error_returns_last_known_state(self):
-        """Test that errors during reading return None to trigger fallback."""
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor.jobDir = "/tmp/test"
-
-        # Bind methods
-        executor._read_job_events = Executor._read_job_events.__get__(
-            executor, Executor
+    def test_shadow_exception_and_reschedule(self, executor):
+        """SUBMIT → EXECUTE → SHADOW_EXCEPTION → EXECUTE → TERMINATED"""
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+                make_event(JobEventType.SHADOW_EXCEPTION),
+                make_event(JobEventType.EXECUTE),
+                make_event(
+                    JobEventType.JOB_TERMINATED, ReturnValue=0, TerminatedNormally=True
+                ),
+            ],
         )
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
-        )
+        assert executor._read_job_events(1).status == JobStatus.COMPLETED
 
-        # Set up initial state
-        executor._job_current_states[12345] = JobState(status=JobStatus.RUNNING)
 
-        # Create a mock that raises an error
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(side_effect=Exception("Read error"))
-        executor._job_event_logs[12345] = mock_event_log
+# ---------------------------------------------------------------------------
+# Error handling & cleanup
+# ---------------------------------------------------------------------------
+class TestErrorHandlingAndCleanup:
+    """Error resilience in event reading and tracking-data cleanup."""
 
-        # Should return None so fallback mechanism can kick in
-        result = executor._read_job_events(12345)
-        assert result is None
+    def test_read_error_returns_none_preserves_state(self):
+        """On exception, _read_job_events returns None (triggers fallback),
+        but preserves last known state for later recovery."""
+        executor = make_mock_executor()
+        executor._job_current_states[1] = JobState(status=JobStatus.RUNNING)
 
-        # But the last known state should still be preserved in _job_current_states
-        assert 12345 in executor._job_current_states
-        assert executor._job_current_states[12345].status == JobStatus.RUNNING
+        mock_log = Mock()
+        mock_log.events = Mock(side_effect=Exception("Read error"))
+        executor._job_event_logs[1] = mock_log
 
-        # Should have logged a warning
+        assert executor._read_job_events(1) is None
+        assert executor._job_current_states[1].status == JobStatus.RUNNING
         assert executor.logger.warning.called
 
+    def test_missing_log_returns_none(self):
+        executor = make_mock_executor(jobDir="/nonexistent/path")
+        assert executor._get_job_event_log(99999) is None
 
-class TestHeldJobTimeout:
-    """Tests for held job timeout behavior."""
+    def test_existing_reader_is_reused(self):
+        executor = make_mock_executor()
+        sentinel = Mock()
+        executor._job_event_logs[1] = sentinel
+        assert executor._get_job_event_log(1) is sentinel
 
-    @pytest.fixture
-    def mock_executor_with_timeout(self):
-        """Create a mock executor with held timeout configured."""
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor.jobDir = "/tmp/test"
-        executor._held_timeout = 3600  # 1 hour timeout for testing
+    def test_cleanup_removes_all_tracking_data(self):
+        executor = make_mock_executor()
+        executor._job_event_logs[1] = Mock()
+        executor._job_current_states[1] = JobState(status=JobStatus.COMPLETED)
+        executor._log_missing_counts[1] = 2
 
-        # Bind methods
-        executor._read_job_events = Executor._read_job_events.__get__(
-            executor, Executor
-        )
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
-        )
-        executor._cleanup_job_tracking = Executor._cleanup_job_tracking.__get__(
-            executor, Executor
-        )
+        executor._cleanup_job_tracking(1)
 
-        return executor
-
-    def test_held_job_within_timeout_stays_active(self, mock_executor_with_timeout):
-        """Held job within timeout should remain in the active jobs list."""
-        executor = mock_executor_with_timeout
-
-        # Job held 30 minutes ago (within 1 hour timeout)
-        executor._job_current_states[12345] = JobState(
-            status=JobStatus.HELD,
-            hold_reason="Memory limit exceeded",
-            held_since=time.time() - 1800,  # 30 minutes ago
-        )
-
-        # Create mock event log that returns no new events
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(return_value=iter([]))
-        executor._job_event_logs[12345] = mock_event_log
-
-        # Read job state
-        result = executor._read_job_events(12345)
-
-        # Job should still be held
-        assert result.status == JobStatus.HELD
-        # held_since should be preserved
-        assert result.held_since is not None
-
-    def test_held_job_past_timeout_can_be_identified(self, mock_executor_with_timeout):
-        """Held job past timeout can be identified by check_active_jobs."""
-        executor = mock_executor_with_timeout
-
-        # Job held 2 hours ago (past 1 hour timeout)
-        held_since = time.time() - 7200  # 2 hours ago
-        executor._job_current_states[12345] = JobState(
-            status=JobStatus.HELD,
-            hold_reason="Memory limit exceeded",
-            held_since=held_since,
-        )
-
-        # The state should reflect that timeout has been exceeded
-        state = executor._job_current_states[12345]
-        elapsed = time.time() - state.held_since
-
-        assert elapsed > executor._held_timeout
-        assert state.status == JobStatus.HELD
-
-    def test_zero_timeout_means_immediate_failure(self):
-        """Timeout of 0 should mean held jobs fail immediately."""
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._held_timeout = 0  # Immediate failure
-
-        # This is configuration validation - held jobs should fail immediately
-        assert executor._held_timeout == 0
+        assert 1 not in executor._job_event_logs
+        assert 1 not in executor._job_current_states
+        assert 1 not in executor._log_missing_counts
 
 
-class TestJobEventLogReadAndCleanup:
-    """Tests for reading job events and cleanup helper methods."""
-
-    @pytest.fixture
-    def mock_executor_for_check(self):
-        """Create a mock executor with check_active_jobs bound."""
-
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor._log_missing_counts = {}
-        executor.jobDir = "/tmp/test_htcondor"
-        executor._held_timeout = 14400  # 4 hour default
-
-        # Bind all the methods needed for check_active_jobs
-        executor._read_job_events = Executor._read_job_events.__get__(
-            executor, Executor
-        )
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
-        )
-        executor._cleanup_job_tracking = Executor._cleanup_job_tracking.__get__(
-            executor, Executor
-        )
-
-        return executor
-
-    def test_completed_job_yields_and_cleans_up(self, mock_executor_for_check):
-        """Verify that completed jobs are yielded and tracking data cleaned up."""
-        from htcondor2 import JobEventType
-
-        executor = mock_executor_for_check
-
-        # Create a completed job state
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(
-                        JobEventType.JOB_TERMINATED,
-                        ReturnValue=0,
-                        TerminatedNormally=True,
-                    ),
-                ]
-            )
-        )
-
-        executor._job_event_logs[12345] = mock_event_log
-
-        # Read events and verify completion
-        result = executor._read_job_events(12345)
-        assert result.status == JobStatus.COMPLETED
-        assert result.exit_code == 0
-
-        # Clean up and verify tracking data is removed
-        executor._cleanup_job_tracking(12345)
-        assert 12345 not in executor._job_event_logs
-        assert 12345 not in executor._job_current_states
-
-    def test_running_job_not_yielded(self, mock_executor_for_check):
-        """Verify that running jobs return their current state."""
-        from htcondor2 import JobEventType
-
-        executor = mock_executor_for_check
-
-        # Set up a running job
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                ]
-            )
-        )
-
-        executor._job_event_logs[12345] = mock_event_log
-
-        # Read events
-        result = executor._read_job_events(12345)
-        assert result.status == JobStatus.RUNNING
-
-        # Tracking data should still exist
-        assert 12345 in executor._job_current_states
-
-    def test_held_job_state_tracked_correctly(self, mock_executor_for_check):
-        """Verify that held jobs have their state tracked correctly."""
-        from htcondor2 import JobEventType
-
-        executor = mock_executor_for_check
-
-        # Set up a held job
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(
-                        JobEventType.JOB_HELD, HoldReason="Memory limit exceeded"
-                    ),
-                ]
-            )
-        )
-
-        executor._job_event_logs[12345] = mock_event_log
-
-        # Read events
-        result = executor._read_job_events(12345)
-        assert result.status == JobStatus.HELD
-        assert result.hold_reason == "Memory limit exceeded"
-        assert result.held_since is not None
-
-
+# ---------------------------------------------------------------------------
+# _report_and_resolve_job_state
+# ---------------------------------------------------------------------------
 class TestReportAndResolveJobState:
-    """Tests for _report_and_resolve_job_state method and job reporting behavior."""
+    """Verify that job states are correctly reported to Snakemake."""
 
     @pytest.fixture
-    def mock_executor_for_processing(self):
-        """Create a mock executor with _report_and_resolve_job_state bound."""
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor._log_missing_counts = {}
-        executor.jobDir = "/tmp/test_htcondor"
-        executor._held_timeout = 14400  # 4 hour default
-
-        # Bind methods needed for processing
-        executor._report_and_resolve_job_state = (
-            Executor._report_and_resolve_job_state.__get__(executor, Executor)
+    def executor(self):
+        ex = make_mock_executor()
+        ex._report_and_resolve_job_state = (
+            Executor._report_and_resolve_job_state.__get__(ex, Executor)
         )
-        executor._cleanup_job_tracking = Executor._cleanup_job_tracking.__get__(
-            executor, Executor
-        )
-
-        # Mock the reporting methods - these are what we want to verify
-        executor.report_job_success = Mock()
-        executor.report_job_error = Mock()
-
-        return executor
+        ex.report_job_success = Mock()
+        ex.report_job_error = Mock()
+        return ex
 
     @pytest.fixture
-    def mock_job_info(self):
-        """Create a mock SubmittedJobInfo."""
-        job_info = Mock()
-        job_info.external_jobid = 12345
-        job_info.job = Mock()
-        job_info.job.jobid = "test_rule"
-        return job_info
+    def job_info(self):
+        ji = Mock()
+        ji.external_jobid = 1
+        ji.job = Mock()
+        ji.job.jobid = "test_rule"
+        return ji
 
-    def test_completed_job_with_exit_code_zero_reports_success(
-        self, mock_executor_for_processing, mock_job_info
-    ):
-        """Verify that completed jobs with exit code 0 call report_job_success."""
-        executor = mock_executor_for_processing
-
-        job_state = JobState(status=JobStatus.COMPLETED, exit_code=0)
-
-        result = executor._report_and_resolve_job_state(mock_job_info, job_state)
-
-        # Should not yield (returns None for terminal states)
+    def test_success_on_exit_zero(self, executor, job_info):
+        result = executor._report_and_resolve_job_state(
+            job_info,
+            JobState(status=JobStatus.COMPLETED, exit_code=0),
+        )
         assert result is None
-        # Should have called report_job_success
-        executor.report_job_success.assert_called_once_with(mock_job_info)
+        executor.report_job_success.assert_called_once_with(job_info)
         executor.report_job_error.assert_not_called()
 
-    def test_completed_job_with_nonzero_exit_reports_error(
-        self, mock_executor_for_processing, mock_job_info
-    ):
-        """Verify that completed jobs with nonzero exit code call report_job_error."""
-        executor = mock_executor_for_processing
-
-        job_state = JobState(status=JobStatus.COMPLETED, exit_code=1)
-
-        result = executor._report_and_resolve_job_state(mock_job_info, job_state)
-
-        assert result is None
-        executor.report_job_error.assert_called_once()
-        executor.report_job_success.assert_not_called()
-        # Verify error message mentions the exit code
-        call_args = executor.report_job_error.call_args
-        assert "ExitCode 1" in call_args.kwargs["msg"]
-
-    def test_completed_job_by_signal_reports_error(
-        self, mock_executor_for_processing, mock_job_info
-    ):
-        """Verify that jobs terminated by signal call report_job_error."""
-        executor = mock_executor_for_processing
-
-        job_state = JobState(
-            status=JobStatus.COMPLETED, exit_by_signal=True, exit_signal=9
+    def test_error_on_nonzero_exit(self, executor, job_info):
+        result = executor._report_and_resolve_job_state(
+            job_info,
+            JobState(status=JobStatus.COMPLETED, exit_code=1),
         )
-
-        result = executor._report_and_resolve_job_state(mock_job_info, job_state)
-
         assert result is None
         executor.report_job_error.assert_called_once()
-        executor.report_job_success.assert_not_called()
-        # Verify error message mentions the signal
-        call_args = executor.report_job_error.call_args
-        assert "signal 9" in call_args.kwargs["msg"]
+        assert "ExitCode 1" in executor.report_job_error.call_args.kwargs["msg"]
 
-    def test_removed_job_reports_error(
-        self, mock_executor_for_processing, mock_job_info
-    ):
-        """Verify that removed/aborted jobs call report_job_error."""
-        executor = mock_executor_for_processing
-
-        job_state = JobState(status=JobStatus.REMOVED)
-
-        result = executor._report_and_resolve_job_state(mock_job_info, job_state)
-
+    def test_error_on_signal_kill(self, executor, job_info):
+        result = executor._report_and_resolve_job_state(
+            job_info,
+            JobState(status=JobStatus.COMPLETED, exit_by_signal=True, exit_signal=9),
+        )
         assert result is None
-        executor.report_job_error.assert_called_once()
-        executor.report_job_success.assert_not_called()
-        # Verify error message mentions removal
-        call_args = executor.report_job_error.call_args
-        assert "removed" in call_args.kwargs["msg"].lower()
+        assert "signal 9" in executor.report_job_error.call_args.kwargs["msg"]
 
-    def test_running_job_yields_and_no_report(
-        self, mock_executor_for_processing, mock_job_info
-    ):
-        """Verify that running jobs yield the job and don't call report methods."""
-        executor = mock_executor_for_processing
+    def test_error_on_removed(self, executor, job_info):
+        result = executor._report_and_resolve_job_state(
+            job_info,
+            JobState(status=JobStatus.REMOVED),
+        )
+        assert result is None
+        assert "removed" in executor.report_job_error.call_args.kwargs["msg"].lower()
 
-        job_state = JobState(status=JobStatus.RUNNING)
-
-        result = executor._report_and_resolve_job_state(mock_job_info, job_state)
-
-        # Should yield the job (return it)
-        assert result is mock_job_info
-        # Should not have called any report methods
+    def test_running_yields_job_no_report(self, executor, job_info):
+        result = executor._report_and_resolve_job_state(
+            job_info,
+            JobState(status=JobStatus.RUNNING),
+        )
+        assert result is job_info
         executor.report_job_success.assert_not_called()
         executor.report_job_error.assert_not_called()
 
-    def test_held_job_past_timeout_reports_error(
-        self, mock_executor_for_processing, mock_job_info
-    ):
-        """Verify that held jobs past timeout call report_job_error."""
-        executor = mock_executor_for_processing
-        executor._held_timeout = 3600  # 1 hour
-
-        job_state = JobState(
-            status=JobStatus.HELD,
-            hold_reason="Memory limit exceeded",
-            held_since=time.time() - 7200,  # 2 hours ago
+    def test_held_past_timeout_reports_error(self, executor, job_info):
+        executor._held_timeout = 3600
+        result = executor._report_and_resolve_job_state(
+            job_info,
+            JobState(
+                status=JobStatus.HELD,
+                hold_reason="Memory limit exceeded",
+                held_since=time.time() - 7200,
+            ),
         )
-
-        result = executor._report_and_resolve_job_state(mock_job_info, job_state)
-
         assert result is None
-        executor.report_job_error.assert_called_once()
-        executor.report_job_success.assert_not_called()
-        # Verify error message mentions hold reason
-        call_args = executor.report_job_error.call_args
-        assert "Memory limit exceeded" in call_args.kwargs["msg"]
-
-    def test_held_job_within_timeout_yields_job(
-        self, mock_executor_for_processing, mock_job_info
-    ):
-        """Verify that held jobs within timeout yield and don't report error."""
-        executor = mock_executor_for_processing
-        executor._held_timeout = 7200  # 2 hours
-
-        job_state = JobState(
-            status=JobStatus.HELD,
-            hold_reason="Memory limit exceeded",
-            held_since=time.time() - 3600,  # 1 hour ago (within 2 hour timeout)
+        assert (
+            "Memory limit exceeded" in executor.report_job_error.call_args.kwargs["msg"]
         )
 
-        result = executor._report_and_resolve_job_state(mock_job_info, job_state)
-
-        # Should yield the job (still active)
-        assert result is mock_job_info
+    def test_held_within_timeout_yields_job(self, executor, job_info):
+        executor._held_timeout = 7200
+        result = executor._report_and_resolve_job_state(
+            job_info,
+            JobState(
+                status=JobStatus.HELD,
+                hold_reason="Memory limit exceeded",
+                held_since=time.time() - 3600,
+            ),
+        )
+        assert result is job_info
         executor.report_job_success.assert_not_called()
         executor.report_job_error.assert_not_called()
 
-    def test_held_job_with_zero_timeout_reports_error_immediately(
-        self, mock_executor_for_processing, mock_job_info
-    ):
-        """Verify that held jobs with timeout=0 fail immediately."""
-        executor = mock_executor_for_processing
-        executor._held_timeout = 0  # Fail immediately
-
-        job_state = JobState(
-            status=JobStatus.HELD,
-            hold_reason="Memory limit exceeded",
-            held_since=time.time(),
+    def test_held_with_zero_timeout_fails_immediately(self, executor, job_info):
+        executor._held_timeout = 0
+        result = executor._report_and_resolve_job_state(
+            job_info,
+            JobState(status=JobStatus.HELD, hold_reason="test", held_since=time.time()),
         )
-
-        result = executor._report_and_resolve_job_state(mock_job_info, job_state)
-
         assert result is None
         executor.report_job_error.assert_called_once()
-        executor.report_job_success.assert_not_called()
 
 
-class TestJobLifecycleScenarios:
-    """Tests for realistic job lifecycle scenarios."""
-
-    @pytest.fixture
-    def mock_executor(self):
-        """Create a mock executor with methods bound."""
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor.jobDir = "/tmp/test"
-
-        executor._read_job_events = Executor._read_job_events.__get__(
-            executor, Executor
-        )
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
-        )
-        executor._cleanup_job_tracking = Executor._cleanup_job_tracking.__get__(
-            executor, Executor
-        )
-
-        return executor
-
-    def test_preemption_and_reschedule(self, mock_executor):
-        """
-        Test job that is preempted (evicted) and rescheduled.
-
-        Lifecycle: SUBMIT -> EXECUTE -> EVICTED -> EXECUTE -> TERMINATED
-        """
-        from htcondor2 import JobEventType
-
-        executor = mock_executor
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(JobEventType.JOB_EVICTED),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(
-                        JobEventType.JOB_TERMINATED,
-                        ReturnValue=0,
-                        TerminatedNormally=True,
-                    ),
-                ]
-            )
-        )
-
-        executor._job_event_logs[12345] = mock_event_log
-
-        result = executor._read_job_events(12345)
-        assert result.status == JobStatus.COMPLETED
-        assert result.exit_code == 0
-
-    def test_hold_and_release(self, mock_executor):
-        """
-        Test job that is held and then released.
-
-        Lifecycle: SUBMIT -> EXECUTE -> HELD -> RELEASED -> EXECUTE -> TERMINATED
-        """
-        from htcondor2 import JobEventType
-
-        executor = mock_executor
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(JobEventType.JOB_HELD, HoldReason="Policy violation"),
-                    make_event(JobEventType.JOB_RELEASED),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(
-                        JobEventType.JOB_TERMINATED,
-                        ReturnValue=0,
-                        TerminatedNormally=True,
-                    ),
-                ]
-            )
-        )
-
-        executor._job_event_logs[12345] = mock_event_log
-
-        result = executor._read_job_events(12345)
-        assert result.status == JobStatus.COMPLETED
-        assert result.hold_reason is None  # Should be cleared after release
-
-    def test_shadow_exception_and_reschedule(self, mock_executor):
-        """
-        Test job that experiences a shadow exception and is rescheduled.
-
-        Lifecycle: SUBMIT -> EXECUTE -> SHADOW_EXCEPTION -> EXECUTE -> TERMINATED
-        """
-        from htcondor2 import JobEventType
-
-        executor = mock_executor
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(JobEventType.SHADOW_EXCEPTION),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(
-                        JobEventType.JOB_TERMINATED,
-                        ReturnValue=0,
-                        TerminatedNormally=True,
-                    ),
-                ]
-            )
-        )
-
-        executor._job_event_logs[12345] = mock_event_log
-
-        result = executor._read_job_events(12345)
-        assert result.status == JobStatus.COMPLETED
-
-    def test_job_killed_by_signal(self, mock_executor):
-        """
-        Test job that is killed by a signal.
-
-        Lifecycle: SUBMIT -> EXECUTE -> TERMINATED (by signal)
-        """
-        from htcondor2 import JobEventType
-
-        executor = mock_executor
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(
-                        JobEventType.JOB_TERMINATED,
-                        ReturnValue=None,
-                        TerminatedNormally=False,
-                        TerminatedBySignal=9,
-                    ),
-                ]
-            )
-        )
-
-        executor._job_event_logs[12345] = mock_event_log
-
-        result = executor._read_job_events(12345)
-        assert result.status == JobStatus.COMPLETED
-        assert result.exit_by_signal is True
-        assert result.exit_signal == 9
-
-    def test_job_removed_by_user(self, mock_executor):
-        """
-        Test job that is removed via condor_rm.
-
-        Lifecycle: SUBMIT -> EXECUTE -> ABORTED
-        """
-        from htcondor2 import JobEventType
-
-        executor = mock_executor
-
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                    make_event(JobEventType.JOB_ABORTED),
-                ]
-            )
-        )
-
-        executor._job_event_logs[12345] = mock_event_log
-
-        result = executor._read_job_events(12345)
-        assert result.status == JobStatus.REMOVED
-
-
+# ---------------------------------------------------------------------------
+# JobStatus enum
+# ---------------------------------------------------------------------------
 class TestJobStatusEnum:
-    """Tests for the JobStatus enum."""
+    """Verify the JobStatus enum values and methods."""
 
-    def test_status_values(self):
-        """Verify all expected status values exist."""
-        assert JobStatus.PENDING.value == "pending"
-        assert JobStatus.IDLE.value == "idle"
-        assert JobStatus.RUNNING.value == "running"
-        assert JobStatus.COMPLETED.value == "completed"
-        assert JobStatus.HELD.value == "held"
-        assert JobStatus.REMOVED.value == "removed"
-        assert JobStatus.TRANSFERRING.value == "transferring"
-        assert JobStatus.SUSPENDED.value == "suspended"
+    def test_all_values_exist(self):
+        expected = {
+            "pending",
+            "idle",
+            "running",
+            "completed",
+            "held",
+            "removed",
+            "transferring",
+            "suspended",
+        }
+        assert {s.value for s in JobStatus} == expected
 
-    def test_display_names(self):
-        """Verify display names are capitalized."""
-        assert JobStatus.PENDING.display_name == "Pending"
-        assert JobStatus.RUNNING.display_name == "Running"
-        assert JobStatus.COMPLETED.display_name == "Completed"
+    def test_display_names_are_capitalized(self):
+        for status in JobStatus:
+            assert status.display_name == status.value.capitalize()
 
-    def test_terminal_states(self):
-        """Verify which states are terminal."""
-        # Only COMPLETED and REMOVED are terminal
-        assert JobStatus.COMPLETED.is_terminal() is True
-        assert JobStatus.REMOVED.is_terminal() is True
-
-        # HELD is NOT terminal - job can be released
-        assert JobStatus.HELD.is_terminal() is False
-
-        # Other states are not terminal
-        assert JobStatus.PENDING.is_terminal() is False
-        assert JobStatus.IDLE.is_terminal() is False
-        assert JobStatus.RUNNING.is_terminal() is False
-        assert JobStatus.TRANSFERRING.is_terminal() is False
-        assert JobStatus.SUSPENDED.is_terminal() is False
+    def test_only_completed_and_removed_are_terminal(self):
+        terminal = {s for s in JobStatus if s.is_terminal()}
+        assert terminal == {JobStatus.COMPLETED, JobStatus.REMOVED}
 
 
-class TestScheddFallback:
-    """Tests for schedd/history fallback when log files are unavailable."""
+# ---------------------------------------------------------------------------
+# Schedd / history fallback
+# ---------------------------------------------------------------------------
+class TestFallbackMechanism:
+    """Fallback mechanism when log files are unavailable."""
 
     @pytest.fixture
-    def mock_executor_with_fallback(self):
-        """Create a mock executor with fallback methods bound."""
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._job_event_logs = {}
-        executor._job_current_states = {}
-        executor._log_missing_counts = {}
-        executor._log_missing_threshold = 3
-        executor._workflow_start_time = int(time.time()) - 3600  # 1 hour ago
-        executor.jobDir = "/tmp/test"
+    def executor(self):
+        return make_mock_executor()
 
-        # Bind methods for the new batch-based approach
-        executor._read_job_events = Executor._read_job_events.__get__(
-            executor, Executor
+    def test_htcondor_status_code_conversion(self, executor):
+        expected = {
+            1: JobStatus.IDLE,
+            2: JobStatus.RUNNING,
+            3: JobStatus.REMOVED,
+            4: JobStatus.COMPLETED,
+            5: JobStatus.HELD,
+            6: JobStatus.TRANSFERRING,
+            7: JobStatus.SUSPENDED,
+            99: JobStatus.PENDING,  # unknown → PENDING
+        }
+        for code, status in expected.items():
+            assert executor._htcondor_status_to_job_status(code) == status
+
+    def test_log_missing_counter_increments(self, executor):
+        executor._try_read_job_log(1)
+        assert executor._log_missing_counts[1] == 1
+        executor._try_read_job_log(1)
+        assert executor._log_missing_counts[1] == 2
+
+    def test_needs_fallback_respects_threshold(self, executor):
+        executor._log_missing_counts[1] = 2
+        assert executor._needs_fallback(1) is False
+        executor._log_missing_counts[1] = 3
+        assert executor._needs_fallback(1) is True
+        executor._log_missing_counts[1] = 5
+        assert executor._needs_fallback(1) is True
+
+    def test_log_missing_counter_resets_on_success(self, executor):
+        executor._log_missing_counts[1] = 2
+        _setup_event_log(
+            executor,
+            1,
+            [
+                make_event(JobEventType.SUBMIT),
+                make_event(JobEventType.EXECUTE),
+            ],
         )
-        executor._get_job_event_log = Executor._get_job_event_log.__get__(
-            executor, Executor
-        )
-        executor._try_read_job_log = Executor._try_read_job_log.__get__(
-            executor, Executor
-        )
-        executor._needs_fallback = Executor._needs_fallback.__get__(executor, Executor)
-        executor._batch_query_schedd = Executor._batch_query_schedd.__get__(
-            executor, Executor
-        )
-        executor._batch_query_history = Executor._batch_query_history.__get__(
-            executor, Executor
-        )
-        executor._htcondor_status_to_job_status = (
-            Executor._htcondor_status_to_job_status.__get__(executor, Executor)
-        )
-
-        return executor
-
-    def test_htcondor_status_conversion(self, mock_executor_with_fallback):
-        """Test conversion of HTCondor status codes to JobStatus enum."""
-        executor = mock_executor_with_fallback
-
-        assert executor._htcondor_status_to_job_status(1) == JobStatus.IDLE
-        assert executor._htcondor_status_to_job_status(2) == JobStatus.RUNNING
-        assert executor._htcondor_status_to_job_status(3) == JobStatus.REMOVED
-        assert executor._htcondor_status_to_job_status(4) == JobStatus.COMPLETED
-        assert executor._htcondor_status_to_job_status(5) == JobStatus.HELD
-        assert executor._htcondor_status_to_job_status(6) == JobStatus.TRANSFERRING
-        assert executor._htcondor_status_to_job_status(7) == JobStatus.SUSPENDED
-        # Unknown status should return PENDING
-        assert executor._htcondor_status_to_job_status(99) == JobStatus.PENDING
-
-    def test_log_missing_count_tracks_failures(self, mock_executor_with_fallback):
-        """Test that log missing count increases on each failed read attempt."""
-        executor = mock_executor_with_fallback
-
-        # First attempt - log not available (returns None)
-        result = executor._try_read_job_log(12345)
-
-        # Should have incremented the counter
-        assert executor._log_missing_counts[12345] == 1
-        assert result is None
-
-        # Second attempt
-        result = executor._try_read_job_log(12345)
-        assert executor._log_missing_counts[12345] == 2
-
-    def test_needs_fallback_respects_threshold(self, mock_executor_with_fallback):
-        """Test that _needs_fallback returns True only after threshold is reached."""
-        executor = mock_executor_with_fallback
-
-        # Below threshold
-        executor._log_missing_counts[12345] = 1
-        assert executor._needs_fallback(12345) is False
-
-        executor._log_missing_counts[12345] = 2
-        assert executor._needs_fallback(12345) is False
-
-        # At threshold
-        executor._log_missing_counts[12345] = 3
-        assert executor._needs_fallback(12345) is True
-
-        # Above threshold
-        executor._log_missing_counts[12345] = 5
-        assert executor._needs_fallback(12345) is True
-
-    def test_log_missing_count_reset_on_success(self, mock_executor_with_fallback):
-        """Test that log missing count is reset when log becomes available."""
-        from htcondor2 import JobEventType
-
-        executor = mock_executor_with_fallback
-
-        # Set up a counter as if we've had some failures
-        executor._log_missing_counts[12345] = 2
-
-        # Now set up a working log
-        mock_event_log = Mock()
-        mock_event_log.events = Mock(
-            return_value=iter(
-                [
-                    make_event(JobEventType.SUBMIT),
-                    make_event(JobEventType.EXECUTE),
-                ]
-            )
-        )
-        executor._job_event_logs[12345] = mock_event_log
-
-        # Read should succeed and reset counter
-        result = executor._try_read_job_log(12345)
-
+        result = executor._try_read_job_log(1)
         assert result.status == JobStatus.RUNNING
-        assert 12345 not in executor._log_missing_counts
+        assert 1 not in executor._log_missing_counts
 
-    def test_batch_query_returns_dict_per_job(self, mock_executor_with_fallback):
-        """Test that batch query methods return a dict keyed by cluster_id."""
-        executor = mock_executor_with_fallback
-
-        # Empty list should return empty dict
-        result = executor._batch_query_schedd([])
-        assert result == {}
-
-        result = executor._batch_query_history([])
-        assert result == {}
-
-
-class TestHistoryFallback:
-    """Tests specific to condor_history fallback."""
-
-    def test_history_uses_workflow_start_time(self):
-        """Verify that workflow start time is tracked for history queries."""
-        executor = Mock(spec=Executor)
-        executor.logger = Mock()
-        executor._workflow_start_time = int(time.time()) - 7200  # 2 hours ago
-
-        # The workflow start time should be set and in the past
-        assert executor._workflow_start_time > 0
-        assert executor._workflow_start_time < time.time()
-
-    def test_batch_approach_prevents_blocking(self):
-        """
-        Verify the two-pass design: log reads are done first for all jobs,
-        then a single batch fallback query is made.
-
-        This test documents the expected behavior: when multiple jobs need
-        fallback, they should all be queried in a single batch call rather
-        than sequentially blocking each other.
-        """
-        # The implementation uses check_active_jobs which:
-        # 1. First pass: tries log files for ALL jobs (fast, non-blocking)
-        # 2. Second pass: batch queries schedd for ALL jobs needing fallback
-        # 3. Third pass: batch queries history for remaining jobs
-        #
-        # This ensures that a slow history query for job1 doesn't block
-        # the status check for job2, job3, etc.
-        #
-        # This is a design documentation test - the actual behavior is
-        # verified by the integration tests in TestCheckActiveJobsIntegration.
-        pass
+    def test_batch_queries_return_empty_for_empty_input(self, executor):
+        assert executor._batch_query_schedd([]) == {}
+        assert executor._batch_query_history([]) == {}

--- a/tests/test_job_event_log.py
+++ b/tests/test_job_event_log.py
@@ -1,0 +1,1142 @@
+"""
+Tests for the JobEventLog-based job status monitoring.
+
+These tests verify that the executor correctly reads HTCondor job event logs
+and interprets job states, replacing the previous schedd query-based approach.
+"""
+
+import pytest
+import time
+from unittest.mock import Mock
+from snakemake_executor_plugin_htcondor import Executor, JobStatus
+
+
+def make_event(event_type, **kwargs):
+    """
+    Helper to create a mock event with the given type.
+
+    This is a module-level helper used by all test classes to avoid duplication.
+
+    Args:
+        event_type: The JobEventType for this event
+        **kwargs: Additional key-value pairs to return from event.get()
+
+    Returns:
+        A Mock event object with the specified type and data
+    """
+    event = Mock()
+    event.type = event_type
+    event.get = Mock(side_effect=lambda k, d=None: kwargs.get(k, d))
+    return event
+
+
+class TestJobEventLogStateTracking:
+    """Tests for job state tracking across multiple check cycles."""
+
+    def test_state_persists_across_reads(self):
+        """
+        Verify that job state is correctly tracked across multiple
+        check cycles when no new events have occurred.
+
+        This tests the core fix for the 'Unknown' status bug where
+        JobEventLog readers advance their position and return no
+        events on subsequent reads.
+        """
+        from htcondor2 import JobEventType
+
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor._job_event_logs = {}
+        executor._job_current_states = {}
+        executor.jobDir = "/tmp/test"
+
+        # Bind methods
+        executor._read_job_events = Executor._read_job_events.__get__(
+            executor, Executor
+        )
+        executor._get_job_event_log = Executor._get_job_event_log.__get__(
+            executor, Executor
+        )
+
+        # Create a mock event log that returns events on first call, empty on second
+        mock_event_log = Mock()
+        call_count = [0]
+
+        def events_generator(stop_after=0):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call: return submit and execute events
+                return iter(
+                    [
+                        make_event(JobEventType.SUBMIT),
+                        make_event(JobEventType.EXECUTE),
+                    ]
+                )
+            else:
+                # Subsequent calls: no new events
+                return iter([])
+
+        mock_event_log.events = Mock(side_effect=events_generator)
+        executor._job_event_logs[12345] = mock_event_log
+
+        # First read
+        result1 = executor._read_job_events(12345)
+        assert result1["status"] == JobStatus.RUNNING
+
+        # Second read (no new events) - should return cached state
+        result2 = executor._read_job_events(12345)
+        assert result2["status"] == JobStatus.RUNNING
+
+    def test_cleanup_removes_tracking_data(self):
+        """Verify that job tracking data is cleaned up after job completes."""
+        executor = Mock(spec=Executor)
+        executor._job_event_logs = {12345: Mock()}
+        executor._job_current_states = {12345: {"status": JobStatus.COMPLETED}}
+        executor.logger = Mock()
+
+        # Bind the cleanup method
+        executor._cleanup_job_tracking = Executor._cleanup_job_tracking.__get__(
+            executor, Executor
+        )
+
+        executor._cleanup_job_tracking(12345)
+
+        assert 12345 not in executor._job_event_logs
+        assert 12345 not in executor._job_current_states
+
+
+class TestJobEventTypes:
+    """Tests for handling different HTCondor job event types."""
+
+    @pytest.fixture
+    def mock_executor(self):
+        """Create a mock executor with the event reading methods bound."""
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor._job_event_logs = {}
+        executor._job_current_states = {}
+        executor.jobDir = "/tmp/test_htcondor"
+
+        # Bind methods
+        executor._read_job_events = Executor._read_job_events.__get__(
+            executor, Executor
+        )
+        executor._get_job_event_log = Executor._get_job_event_log.__get__(
+            executor, Executor
+        )
+        executor._cleanup_job_tracking = Executor._cleanup_job_tracking.__get__(
+            executor, Executor
+        )
+
+        return executor
+
+    def test_submit_event_sets_idle(self, mock_executor):
+        """SUBMIT event (type 0) should set status to IDLE."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter([make_event(JobEventType.SUBMIT)])
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.IDLE
+
+    def test_execute_event_sets_running(self, mock_executor):
+        """EXECUTE event (type 1) should set status to RUNNING."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.RUNNING
+
+    def test_terminated_event_sets_completed(self, mock_executor):
+        """JOB_TERMINATED event (type 5) should set status to COMPLETED."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(
+                        JobEventType.JOB_TERMINATED,
+                        ReturnValue=0,
+                        TerminatedNormally=True,
+                    ),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.COMPLETED
+        assert result["exit_code"] == 0
+        assert result["exit_by_signal"] is False
+
+    def test_terminated_with_nonzero_exit(self, mock_executor):
+        """JOB_TERMINATED with non-zero exit code should be captured."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(
+                        JobEventType.JOB_TERMINATED,
+                        ReturnValue=42,
+                        TerminatedNormally=True,
+                    ),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.COMPLETED
+        assert result["exit_code"] == 42
+
+    def test_held_event_sets_held_with_timestamp(self, mock_executor):
+        """JOB_HELD event (type 12) should set status to HELD and record timestamp."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(
+                        JobEventType.JOB_HELD, HoldReason="Job exceeded memory limit"
+                    ),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        before_time = time.time()
+        result = mock_executor._read_job_events(12345)
+        after_time = time.time()
+
+        assert result is not None
+        assert result["status"] == JobStatus.HELD
+        assert result["hold_reason"] == "Job exceeded memory limit"
+        # Verify held_since is set to approximately the current time
+        assert result["held_since"] is not None
+        assert before_time <= result["held_since"] <= after_time
+
+    def test_aborted_event_sets_removed(self, mock_executor):
+        """JOB_ABORTED event (type 9) should set status to REMOVED."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.JOB_ABORTED),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.REMOVED
+
+    def test_evicted_event_sets_idle(self, mock_executor):
+        """JOB_EVICTED event should set status back to IDLE."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(JobEventType.JOB_EVICTED),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.IDLE
+
+    def test_suspended_event_sets_suspended(self, mock_executor):
+        """JOB_SUSPENDED event should set status to SUSPENDED."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(JobEventType.JOB_SUSPENDED),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.SUSPENDED
+
+    def test_unsuspended_event_sets_running(self, mock_executor):
+        """JOB_UNSUSPENDED event should set status back to RUNNING."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(JobEventType.JOB_SUSPENDED),
+                    make_event(JobEventType.JOB_UNSUSPENDED),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.RUNNING
+
+    def test_released_event_clears_held_state(self, mock_executor):
+        """JOB_RELEASED event should set status back to IDLE and clear held_since."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.JOB_HELD, HoldReason="Test hold reason"),
+                    make_event(JobEventType.JOB_RELEASED),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.IDLE
+        # hold_reason and held_since should be cleared after release
+        assert result["hold_reason"] is None
+        assert result["held_since"] is None
+
+    def test_file_transfer_event_sets_transferring(self, mock_executor):
+        """FILE_TRANSFER event should set status to TRANSFERRING when not running."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.FILE_TRANSFER),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.TRANSFERRING
+
+    def test_file_transfer_does_not_override_running(self, mock_executor):
+        """FILE_TRANSFER event should not override RUNNING status."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),  # Now running
+                    make_event(JobEventType.FILE_TRANSFER),  # Output transfer
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        # Should still be RUNNING, not TRANSFERRING
+        assert result["status"] == JobStatus.RUNNING
+
+    def test_image_size_event_does_not_change_status(self, mock_executor):
+        """IMAGE_SIZE event should not change the job status."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(JobEventType.IMAGE_SIZE),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.RUNNING  # Still running
+
+    def test_shadow_exception_sets_idle(self, mock_executor):
+        """SHADOW_EXCEPTION event should set status to IDLE (for reschedule)."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(JobEventType.SHADOW_EXCEPTION),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.IDLE
+
+    def test_reconnect_failed_sets_idle(self, mock_executor):
+        """JOB_RECONNECT_FAILED event should set status to IDLE."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(JobEventType.JOB_RECONNECT_FAILED),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.IDLE
+
+    def test_reconnected_sets_running(self, mock_executor):
+        """JOB_RECONNECTED event should set status to RUNNING."""
+        from htcondor2 import JobEventType
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(JobEventType.JOB_DISCONNECTED),
+                    make_event(JobEventType.JOB_RECONNECTED),
+                ]
+            )
+        )
+
+        mock_executor._job_event_logs[12345] = mock_event_log
+
+        result = mock_executor._read_job_events(12345)
+
+        assert result is not None
+        assert result["status"] == JobStatus.RUNNING
+
+
+class TestStatePersistenceAcrossReads:
+    """
+    Tests verifying that state persists correctly when no new events are available.
+
+    This specifically tests the fix for the 'Unknown' status bug.
+    """
+
+    def test_second_read_returns_cached_state(self):
+        """
+        Verify that the second read (with no new events) returns
+        the last known state, not 'pending'/'unknown'.
+        """
+        from htcondor2 import JobEventType
+
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor._job_event_logs = {}
+        executor._job_current_states = {}
+        executor.jobDir = "/tmp/test"
+
+        # Bind methods
+        executor._read_job_events = Executor._read_job_events.__get__(
+            executor, Executor
+        )
+        executor._get_job_event_log = Executor._get_job_event_log.__get__(
+            executor, Executor
+        )
+
+        # Create a mock event log that returns events on first call, empty on second
+        mock_event_log = Mock()
+        call_count = [0]
+
+        def events_generator(stop_after=0):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call: return submit and execute events
+                return iter(
+                    [
+                        make_event(JobEventType.SUBMIT),
+                        make_event(JobEventType.EXECUTE),
+                    ]
+                )
+            else:
+                # Subsequent calls: no new events
+                return iter([])
+
+        mock_event_log.events = Mock(side_effect=events_generator)
+        executor._job_event_logs[12345] = mock_event_log
+
+        # First read
+        result1 = executor._read_job_events(12345)
+        assert result1["status"] == JobStatus.RUNNING
+
+        # Second read (no new events)
+        result2 = executor._read_job_events(12345)
+        assert (
+            result2["status"] == JobStatus.RUNNING
+        )  # Should still be RUNNING, not PENDING
+
+    def test_terminal_state_cached_and_returned(self):
+        """
+        Verify that terminal states (completed, removed) are
+        returned without re-reading the log.
+        """
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor._job_event_logs = {}
+        executor._job_current_states = {}
+        executor.jobDir = "/tmp/test"
+
+        # Bind methods
+        executor._read_job_events = Executor._read_job_events.__get__(
+            executor, Executor
+        )
+        executor._get_job_event_log = Executor._get_job_event_log.__get__(
+            executor, Executor
+        )
+
+        # Pre-populate with a terminal state
+        executor._job_current_states[12345] = {
+            "status": JobStatus.COMPLETED,
+            "exit_code": 0,
+            "exit_by_signal": False,
+            "exit_signal": None,
+            "hold_reason": None,
+            "held_since": None,
+        }
+
+        # Should return cached state without reading log
+        result = executor._read_job_events(12345)
+
+        assert result["status"] == JobStatus.COMPLETED
+        assert result["exit_code"] == 0
+
+    def test_held_state_is_not_terminal(self):
+        """
+        Verify that held state is NOT cached as terminal - it should
+        continue to read events in case job is released.
+        """
+        from htcondor2 import JobEventType
+
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor._job_event_logs = {}
+        executor._job_current_states = {}
+        executor.jobDir = "/tmp/test"
+
+        # Bind methods
+        executor._read_job_events = Executor._read_job_events.__get__(
+            executor, Executor
+        )
+        executor._get_job_event_log = Executor._get_job_event_log.__get__(
+            executor, Executor
+        )
+
+        # Pre-populate with a held state
+        executor._job_current_states[12345] = {
+            "status": JobStatus.HELD,
+            "exit_code": None,
+            "exit_by_signal": False,
+            "exit_signal": None,
+            "hold_reason": "Test reason",
+            "held_since": time.time() - 60,  # Held for 1 minute
+        }
+
+        # Create a mock event log that returns a RELEASED event
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.JOB_RELEASED),
+                ]
+            )
+        )
+        executor._job_event_logs[12345] = mock_event_log
+
+        # Read should process the release event
+        result = executor._read_job_events(12345)
+
+        # Job should now be IDLE, not still HELD
+        assert result["status"] == JobStatus.IDLE
+        assert result["hold_reason"] is None
+        assert result["held_since"] is None
+
+
+class TestLogFileInitialization:
+    """Tests for lazy log file initialization."""
+
+    def test_lazy_initialization_when_file_not_ready(self):
+        """Test that missing log files don't cause errors."""
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor._job_event_logs = {}
+        executor._job_current_states = {}
+        executor.jobDir = "/nonexistent/path"
+
+        # Bind method
+        executor._get_job_event_log = Executor._get_job_event_log.__get__(
+            executor, Executor
+        )
+
+        # Should return None, not raise
+        result = executor._get_job_event_log(99999)
+        assert result is None
+
+    def test_returns_existing_reader(self):
+        """Test that existing readers are returned without creating new ones."""
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor.jobDir = "/tmp/test"
+
+        existing_reader = Mock()
+        executor._job_event_logs = {12345: existing_reader}
+
+        # Bind method
+        executor._get_job_event_log = Executor._get_job_event_log.__get__(
+            executor, Executor
+        )
+
+        result = executor._get_job_event_log(12345)
+        assert result is existing_reader
+
+
+class TestErrorHandling:
+    """Tests for error handling in event reading."""
+
+    def test_error_returns_last_known_state(self):
+        """Test that errors during reading return the last known state."""
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor._job_event_logs = {}
+        executor._job_current_states = {}
+        executor.jobDir = "/tmp/test"
+
+        # Bind methods
+        executor._read_job_events = Executor._read_job_events.__get__(
+            executor, Executor
+        )
+        executor._get_job_event_log = Executor._get_job_event_log.__get__(
+            executor, Executor
+        )
+
+        # Set up initial state
+        executor._job_current_states[12345] = {
+            "status": JobStatus.RUNNING,
+            "exit_code": None,
+            "exit_by_signal": False,
+            "exit_signal": None,
+            "hold_reason": None,
+            "held_since": None,
+        }
+
+        # Create a mock that raises an error
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(side_effect=Exception("Read error"))
+        executor._job_event_logs[12345] = mock_event_log
+
+        # Should return last known state despite error
+        result = executor._read_job_events(12345)
+        assert result["status"] == JobStatus.RUNNING
+
+        # Should have logged a warning
+        assert executor.logger.warning.called
+
+
+class TestHeldJobTimeout:
+    """Tests for held job timeout behavior."""
+
+    @pytest.fixture
+    def mock_executor_with_timeout(self):
+        """Create a mock executor with held timeout configured."""
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor._job_event_logs = {}
+        executor._job_current_states = {}
+        executor.jobDir = "/tmp/test"
+        executor._held_timeout = 3600  # 1 hour timeout for testing
+
+        # Bind methods
+        executor._read_job_events = Executor._read_job_events.__get__(
+            executor, Executor
+        )
+        executor._get_job_event_log = Executor._get_job_event_log.__get__(
+            executor, Executor
+        )
+        executor._cleanup_job_tracking = Executor._cleanup_job_tracking.__get__(
+            executor, Executor
+        )
+
+        return executor
+
+    def test_held_job_within_timeout_stays_active(self, mock_executor_with_timeout):
+        """Held job within timeout should remain in the active jobs list."""
+        executor = mock_executor_with_timeout
+
+        # Job held 30 minutes ago (within 1 hour timeout)
+        executor._job_current_states[12345] = {
+            "status": JobStatus.HELD,
+            "exit_code": None,
+            "exit_by_signal": False,
+            "exit_signal": None,
+            "hold_reason": "Memory limit exceeded",
+            "held_since": time.time() - 1800,  # 30 minutes ago
+        }
+
+        # Create mock event log that returns no new events
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(return_value=iter([]))
+        executor._job_event_logs[12345] = mock_event_log
+
+        # Read job state
+        result = executor._read_job_events(12345)
+
+        # Job should still be held
+        assert result["status"] == JobStatus.HELD
+        # held_since should be preserved
+        assert result["held_since"] is not None
+
+    def test_held_job_past_timeout_can_be_identified(self, mock_executor_with_timeout):
+        """Held job past timeout can be identified by check_active_jobs."""
+        executor = mock_executor_with_timeout
+
+        # Job held 2 hours ago (past 1 hour timeout)
+        held_since = time.time() - 7200  # 2 hours ago
+        executor._job_current_states[12345] = {
+            "status": JobStatus.HELD,
+            "exit_code": None,
+            "exit_by_signal": False,
+            "exit_signal": None,
+            "hold_reason": "Memory limit exceeded",
+            "held_since": held_since,
+        }
+
+        # The state should reflect that timeout has been exceeded
+        state = executor._job_current_states[12345]
+        elapsed = time.time() - state["held_since"]
+
+        assert elapsed > executor._held_timeout
+        assert state["status"] == JobStatus.HELD
+
+    def test_zero_timeout_means_immediate_failure(self):
+        """Timeout of 0 should mean held jobs fail immediately."""
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor._held_timeout = 0  # Immediate failure
+
+        # This is configuration validation - held jobs should fail immediately
+        assert executor._held_timeout == 0
+
+
+class TestCheckActiveJobsIntegration:
+    """Tests for the full check_active_jobs integration."""
+
+    @pytest.fixture
+    def mock_executor_for_check(self):
+        """Create a mock executor with check_active_jobs bound."""
+
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor._job_event_logs = {}
+        executor._job_current_states = {}
+        executor.jobDir = "/tmp/test_htcondor"
+        executor._held_timeout = 14400  # 4 hour default
+
+        # Bind all the methods needed for check_active_jobs
+        executor._read_job_events = Executor._read_job_events.__get__(
+            executor, Executor
+        )
+        executor._get_job_event_log = Executor._get_job_event_log.__get__(
+            executor, Executor
+        )
+        executor._cleanup_job_tracking = Executor._cleanup_job_tracking.__get__(
+            executor, Executor
+        )
+
+        return executor
+
+    def test_completed_job_yields_and_cleans_up(self, mock_executor_for_check):
+        """Verify that completed jobs are yielded and tracking data cleaned up."""
+        from htcondor2 import JobEventType
+
+        executor = mock_executor_for_check
+
+        # Create a completed job state
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(
+                        JobEventType.JOB_TERMINATED,
+                        ReturnValue=0,
+                        TerminatedNormally=True,
+                    ),
+                ]
+            )
+        )
+
+        executor._job_event_logs[12345] = mock_event_log
+
+        # Read events and verify completion
+        result = executor._read_job_events(12345)
+        assert result["status"] == JobStatus.COMPLETED
+        assert result["exit_code"] == 0
+
+        # Clean up and verify tracking data is removed
+        executor._cleanup_job_tracking(12345)
+        assert 12345 not in executor._job_event_logs
+        assert 12345 not in executor._job_current_states
+
+    def test_running_job_not_yielded(self, mock_executor_for_check):
+        """Verify that running jobs return their current state."""
+        from htcondor2 import JobEventType
+
+        executor = mock_executor_for_check
+
+        # Set up a running job
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                ]
+            )
+        )
+
+        executor._job_event_logs[12345] = mock_event_log
+
+        # Read events
+        result = executor._read_job_events(12345)
+        assert result["status"] == JobStatus.RUNNING
+
+        # Tracking data should still exist
+        assert 12345 in executor._job_current_states
+
+    def test_held_job_state_tracked_correctly(self, mock_executor_for_check):
+        """Verify that held jobs have their state tracked correctly."""
+        from htcondor2 import JobEventType
+
+        executor = mock_executor_for_check
+
+        # Set up a held job
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(
+                        JobEventType.JOB_HELD, HoldReason="Memory limit exceeded"
+                    ),
+                ]
+            )
+        )
+
+        executor._job_event_logs[12345] = mock_event_log
+
+        # Read events
+        result = executor._read_job_events(12345)
+        assert result["status"] == JobStatus.HELD
+        assert result["hold_reason"] == "Memory limit exceeded"
+        assert result["held_since"] is not None
+
+
+class TestJobLifecycleScenarios:
+    """Tests for realistic job lifecycle scenarios."""
+
+    @pytest.fixture
+    def mock_executor(self):
+        """Create a mock executor with methods bound."""
+        executor = Mock(spec=Executor)
+        executor.logger = Mock()
+        executor._job_event_logs = {}
+        executor._job_current_states = {}
+        executor.jobDir = "/tmp/test"
+
+        executor._read_job_events = Executor._read_job_events.__get__(
+            executor, Executor
+        )
+        executor._get_job_event_log = Executor._get_job_event_log.__get__(
+            executor, Executor
+        )
+        executor._cleanup_job_tracking = Executor._cleanup_job_tracking.__get__(
+            executor, Executor
+        )
+
+        return executor
+
+    def test_preemption_and_reschedule(self, mock_executor):
+        """
+        Test job that is preempted (evicted) and rescheduled.
+
+        Lifecycle: SUBMIT -> EXECUTE -> EVICTED -> EXECUTE -> TERMINATED
+        """
+        from htcondor2 import JobEventType
+
+        executor = mock_executor
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(JobEventType.JOB_EVICTED),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(
+                        JobEventType.JOB_TERMINATED,
+                        ReturnValue=0,
+                        TerminatedNormally=True,
+                    ),
+                ]
+            )
+        )
+
+        executor._job_event_logs[12345] = mock_event_log
+
+        result = executor._read_job_events(12345)
+        assert result["status"] == JobStatus.COMPLETED
+        assert result["exit_code"] == 0
+
+    def test_hold_and_release(self, mock_executor):
+        """
+        Test job that is held and then released.
+
+        Lifecycle: SUBMIT -> EXECUTE -> HELD -> RELEASED -> EXECUTE -> TERMINATED
+        """
+        from htcondor2 import JobEventType
+
+        executor = mock_executor
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(JobEventType.JOB_HELD, HoldReason="Policy violation"),
+                    make_event(JobEventType.JOB_RELEASED),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(
+                        JobEventType.JOB_TERMINATED,
+                        ReturnValue=0,
+                        TerminatedNormally=True,
+                    ),
+                ]
+            )
+        )
+
+        executor._job_event_logs[12345] = mock_event_log
+
+        result = executor._read_job_events(12345)
+        assert result["status"] == JobStatus.COMPLETED
+        assert result["hold_reason"] is None  # Should be cleared after release
+
+    def test_shadow_exception_and_reschedule(self, mock_executor):
+        """
+        Test job that experiences a shadow exception and is rescheduled.
+
+        Lifecycle: SUBMIT -> EXECUTE -> SHADOW_EXCEPTION -> EXECUTE -> TERMINATED
+        """
+        from htcondor2 import JobEventType
+
+        executor = mock_executor
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(JobEventType.SHADOW_EXCEPTION),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(
+                        JobEventType.JOB_TERMINATED,
+                        ReturnValue=0,
+                        TerminatedNormally=True,
+                    ),
+                ]
+            )
+        )
+
+        executor._job_event_logs[12345] = mock_event_log
+
+        result = executor._read_job_events(12345)
+        assert result["status"] == JobStatus.COMPLETED
+
+    def test_job_killed_by_signal(self, mock_executor):
+        """
+        Test job that is killed by a signal.
+
+        Lifecycle: SUBMIT -> EXECUTE -> TERMINATED (by signal)
+        """
+        from htcondor2 import JobEventType
+
+        executor = mock_executor
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(
+                        JobEventType.JOB_TERMINATED,
+                        ReturnValue=None,
+                        TerminatedNormally=False,
+                        TerminatedBySignal=9,
+                    ),
+                ]
+            )
+        )
+
+        executor._job_event_logs[12345] = mock_event_log
+
+        result = executor._read_job_events(12345)
+        assert result["status"] == JobStatus.COMPLETED
+        assert result["exit_by_signal"] is True
+        assert result["exit_signal"] == 9
+
+    def test_job_removed_by_user(self, mock_executor):
+        """
+        Test job that is removed via condor_rm.
+
+        Lifecycle: SUBMIT -> EXECUTE -> ABORTED
+        """
+        from htcondor2 import JobEventType
+
+        executor = mock_executor
+
+        mock_event_log = Mock()
+        mock_event_log.events = Mock(
+            return_value=iter(
+                [
+                    make_event(JobEventType.SUBMIT),
+                    make_event(JobEventType.EXECUTE),
+                    make_event(JobEventType.JOB_ABORTED),
+                ]
+            )
+        )
+
+        executor._job_event_logs[12345] = mock_event_log
+
+        result = executor._read_job_events(12345)
+        assert result["status"] == JobStatus.REMOVED
+
+
+class TestJobStatusEnum:
+    """Tests for the JobStatus enum."""
+
+    def test_status_values(self):
+        """Verify all expected status values exist."""
+        assert JobStatus.PENDING.value == "pending"
+        assert JobStatus.IDLE.value == "idle"
+        assert JobStatus.RUNNING.value == "running"
+        assert JobStatus.COMPLETED.value == "completed"
+        assert JobStatus.HELD.value == "held"
+        assert JobStatus.REMOVED.value == "removed"
+        assert JobStatus.TRANSFERRING.value == "transferring"
+        assert JobStatus.SUSPENDED.value == "suspended"
+
+    def test_display_names(self):
+        """Verify display names are capitalized."""
+        assert JobStatus.PENDING.display_name == "Pending"
+        assert JobStatus.RUNNING.display_name == "Running"
+        assert JobStatus.COMPLETED.display_name == "Completed"
+
+    def test_terminal_states(self):
+        """Verify which states are terminal."""
+        # Only COMPLETED and REMOVED are terminal
+        assert JobStatus.COMPLETED.is_terminal() is True
+        assert JobStatus.REMOVED.is_terminal() is True
+
+        # HELD is NOT terminal - job can be released
+        assert JobStatus.HELD.is_terminal() is False
+
+        # Other states are not terminal
+        assert JobStatus.PENDING.is_terminal() is False
+        assert JobStatus.IDLE.is_terminal() is False
+        assert JobStatus.RUNNING.is_terminal() is False
+        assert JobStatus.TRANSFERRING.is_terminal() is False
+        assert JobStatus.SUSPENDED.is_terminal() is False


### PR DESCRIPTION
As the title states, this switches job monitoring to use job logs instead of condor_history and the schedd.

I wasn't sure what to do with held jobs (should they count as terminal?), so I decided Snakemake should give users time to modify/release anything that gets held, but if it's not released in a few hours, fail the workflow.