### PR TITLE
Harden file transfers

### DIFF
--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -761,6 +761,14 @@ class Executor(RemoteExecutor):
                 remap = f"{out_path} = {out_path}"
             else:
                 abs_ap_dest = normpath(join(workdir, out_path))
+                if not abs_ap_dest.startswith(workdir):
+                    self.logger.warning(
+                        f"Output file '{out_path}' resolves to '{abs_ap_dest}', "
+                        f"which is outside the working directory '{workdir}'. "
+                        "This remap may overwrite files in unexpected locations "
+                        "on the Access Point. Consider using output paths that "
+                        "stay within the workflow working directory."
+                    )
                 remap = f"{out_path} = {abs_ap_dest}"
             if remap not in transfer_output_remaps:
                 transfer_output_remaps.append(remap)

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -761,7 +761,10 @@ class Executor(RemoteExecutor):
                 remap = f"{out_path} = {out_path}"
             else:
                 abs_ap_dest = normpath(join(workdir, out_path))
-                if not abs_ap_dest.startswith(workdir):
+                # Use workdir + sep to prevent prefix collisions:
+                # e.g. "/ap/workdir_evil/f" would wrongly pass startswith("/ap/workdir")
+                workdir_prefix = workdir if workdir.endswith(sep) else workdir + sep
+                if not abs_ap_dest.startswith(workdir_prefix):
                     self.logger.warning(
                         f"Output file '{out_path}' resolves to '{abs_ap_dest}', "
                         f"which is outside the working directory '{workdir}'. "

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -129,7 +129,8 @@ common_settings = CommonSettings(
     # Whether the executor implies to not have a shared file system
     implies_no_shared_fs=False,
     # whether to deploy workflow sources to default storage provider before execution
-    job_deploy_sources=True,
+    # --> This only triggers when ``can_transfer_local_files`` is False, so no need to enable.
+    job_deploy_sources=False,
     # whether arguments for setting the storage provider shall be passed to jobs
     pass_default_storage_provider_args=True,
     # whether arguments for setting default resources shall be passed to jobs
@@ -137,7 +138,11 @@ common_settings = CommonSettings(
     # whether environment variables shall be passed to jobs (if False, use
     # self.envvars() to obtain a dict of environment variables and their values
     # and pass them e.g. as secrets to the execution backend)
-    pass_envvar_declarations_to_cmd=True,
+    # Set to False: we inject env vars via HTCondor's native `environment` key
+    # in run_job() instead. Embedding them inline as "export VAR=val &&" in the
+    # arguments string breaks the job_wrapper path because the arguments string
+    # would no longer start with "python -m snakemake" and prefix-stripping fails.
+    pass_envvar_declarations_to_cmd=False,
     # whether the default storage provider shall be deployed before the job is run on
     # the remote node. Usually set to True if the executor does not assume a shared fs
     auto_deploy_default_storage_provider=True,
@@ -267,26 +272,59 @@ class Executor(RemoteExecutor):
 
     def _add_file_if_transferable(
         self,
-        file_path: str,
+        file_path,
         transfer_list: List[str],
         expand_wildcards: bool = False,
         job: Optional[JobExecutorInterface] = None,
         validate_exists: bool = True,
-    ) -> None:
+        warn_absolute: bool = False,
+        skip_temp: bool = False,
+    ) -> bool:
         """
         Add a file to the transfer list if it's not on a shared filesystem.
 
+        This is the single gatekeeper for both input and output transfer lists.
+        It handles temp-file skipping, shared-FS filtering, absolute-path
+        warnings, normalization, and deduplication.
+
         Args:
-            file_path: Path to potentially transfer
+            file_path: Path to the file to potentially transfer.  May be a
+                string or a Snakemake path object (e.g. with ``.flags``).
             transfer_list: List to add the file to
             expand_wildcards: Whether to expand wildcards/params in the path
             job: Job object (required if expand_wildcards is True)
-            validate_exists: Whether to validate file existence (default True)
+            validate_exists: Whether to validate file existence (default True).
+                Set to False for output files that do not exist yet.
+            warn_absolute: If True, log a warning when the path is absolute and
+                not on a shared filesystem prefix.
+            skip_temp: If True, skip paths whose ``.flags["temp"]`` is set.
+                Use this for output files — temp() outputs are deleted on the EP
+                during group execution and must not be listed for transfer.
+
+        Returns:
+            True if the file was added to *transfer_list*, False if it was
+            skipped for any reason (empty path, temp, shared FS, duplicate, …).
         """
         # Explicitly handle empty/None filepaths
         if file_path is None or str(file_path).strip() == "":
             self.logger.debug("Skipping empty or None filepath")
-            return
+            return False
+
+        # Skip temp() outputs — the EP deletes them during group execution once
+        # they've been consumed by their downstream rule.  Declaring them in
+        # transfer_output_files would cause HTCondor to error when it can't find
+        # the already-deleted file at transfer time.  This check must happen
+        # before the str() conversion so we can inspect the Snakemake path
+        # object's .flags attribute.
+        if (
+            skip_temp
+            and hasattr(file_path, "flags")
+            and file_path.flags.get("temp", False)
+        ):
+            self.logger.debug(
+                f"Skipping temp file (deleted on EP during execution): {file_path}"
+            )
+            return False
 
         file_path = str(file_path).strip()
 
@@ -310,14 +348,27 @@ class Executor(RemoteExecutor):
         # Check if already in transfer list (after normalization)
         if file_path in transfer_list:
             self.logger.debug(f"File already in transfer list: {file_path}")
-            return
+            return False
 
         # Check if on shared filesystem
         if is_shared_fs(file_path, self.shared_fs_prefixes):
             self.logger.debug(
                 f"File on shared filesystem, skipping transfer: {file_path}"
             )
-            return
+            return False
+
+        # Warn when an absolute path is used for a job file in no-shared-fs mode.
+        # Absolute paths are likely to cause job failure on the execution point
+        # because the EP scratch directory will not have that absolute path.
+        if warn_absolute and isabs(file_path):
+            self.logger.warning(
+                f"File '{file_path}' uses an absolute path and is not under any "
+                "configured shared filesystem prefix. When running without a globally "
+                "shared filesystem, absolute paths for job files are likely to cause "
+                "job failure — the execution point will not have access to this path. "
+                "Declare these files using paths relative to the submit directory "
+                "instead. Attempting job submission anyway."
+            )
 
         # Validate file existence if requested
         if validate_exists and not exists(file_path):
@@ -328,6 +379,7 @@ class Executor(RemoteExecutor):
 
         self.logger.debug(f"Adding file to transfer list: {file_path}")
         transfer_list.append(file_path)
+        return True
 
     def _add_module_snakefiles(
         self,
@@ -402,6 +454,30 @@ class Executor(RemoteExecutor):
             return [f.strip() for f in files_spec.split(",") if f.strip()]
         else:
             return list(files_spec)
+
+    def _format_htcondor_environment(self, envvars: dict) -> str:
+        """
+        Serialize a dict of environment variables to HTCondor's new-style
+        environment string format.
+
+        HTCondor new-style format places each assignment as KEY="value",
+        separated by spaces.  Double-quote characters inside a value are
+        escaped by doubling them (e.g. a value containing '"' becomes '""').
+
+        Example output: 'SNAKEMAKE_STORAGE_S3_REGION="us-east-1" FOO="bar"'
+
+        Args:
+            envvars: Dict mapping variable names to their string values.
+
+        Returns:
+            HTCondor new-style environment string, ready to assign to the
+            ``environment`` key in an htcondor.Submit dict.
+        """
+        parts = []
+        for k, v in envvars.items():
+            v_escaped = str(v).replace('"', '""')
+            parts.append(f'{k}="{v_escaped}"')
+        return " ".join(parts)
 
     def _format_size_mb(self, mb_value: int) -> str:
         """
@@ -514,21 +590,34 @@ class Executor(RemoteExecutor):
 
     def _get_files_for_transfer(
         self, job: JobExecutorInterface
-    ) -> tuple[List[str], List[str]]:
+    ) -> tuple[List[str], List[str], List[str]]:
         """
         Determine which input and output files need to be transferred by HTCondor.
 
         Files on shared filesystem prefixes are excluded from transfer.
 
+        Output files are transferred explicitly (not as top-level directories) so
+        that only declared outputs are touched on the AP after a job completes.
+        This prevents Snakemake's mtime-based dependency tracking from being
+        invalidated when an output directory also contains inputs for a later rule.
+
+        A ``transfer_output_remaps`` list is returned alongside the output files
+        so that each output lands at its correct absolute destination on the AP
+        rather than relying solely on HTCondor's ``preserve_relative_paths``
+        semantics.
+
         Args:
             job: The job being prepared for submission
 
         Returns:
-            Tuple of (transfer_input_files, transfer_output_files) lists
+            Tuple of (transfer_input_files, transfer_output_files,
+            transfer_output_remaps) where transfer_output_remaps is a list of
+            HTCondor remap strings in the form ``"ep_path = ap_absolute_path"``.
         """
         self.logger.debug(f"Determining files for transfer for job: {job}")
         transfer_input_files = []
-        transfer_output_files = []
+        transfer_output_files = []  # explicit EP output paths
+        transfer_output_remaps = []  # HTCondor remap strings: "ep_path = ap_abs_path"
 
         # Add the main snakefile to the transfer list if not on shared filesystem
         main_snakefile = self.get_snakefile()
@@ -549,71 +638,68 @@ class Executor(RemoteExecutor):
                 inputs = {path.split(sep)[0] for path in inputs}
 
             for path in inputs:
-                self._add_file_if_transferable(path, transfer_input_files)
+                self._add_file_if_transferable(
+                    path, transfer_input_files, warn_absolute=True
+                )
 
         # NOTE: Config files are handled separately by _prepare_config_files_for_transfer()
         # which returns relative paths for both the job arguments and the transfer list.
 
-        # Process output files (only transfer top-most output directories)
-        # NOTE: For outputs, we only transfer top-level directories to avoid
-        # transferring deeply nested structures. HTCondor will bring back the
-        # entire directory tree from the execution point.
-        if job.output:
-            top_most_output_directories = {path.split(sep)[0] for path in job.output}
-            for path in top_most_output_directories:
-                self._add_file_if_transferable(
-                    path, transfer_output_files, validate_exists=False
-                )
+        # Process output files — transfer each declared output explicitly.
+        #
+        # Previously the executor transferred only the top-most output directory
+        # (e.g. "output/" for any file under output/).  That caused a subtle
+        # mtime bug: when a rule's inputs and outputs share a directory (e.g.
+        # both rule 1's outputs and rule 2's inputs live in "output/"), HTCondor
+        # would transfer the entire directory back to the AP, touching the input
+        # files and breaking Snakemake's mtime-based dependency tracking.
+        #
+        # GROUP JOB SPECIAL CASE: job.output for a GroupJob contains only the
+        # group's *external* outputs — those consumed by rules outside the group.
+        # Internal intermediates are NOT in job.output.  However, Snakemake's
+        # postprocess step checks ALL outputs of ALL rules in the group for
+        # existence on the AP after the job completes.  The fix is to also
+        # collect outputs from each individual job via job.jobs.
+        all_output_paths = list(job.output) if job.output else []
+        if job.is_group() and hasattr(job, "jobs"):
+            seen_paths = {str(p) for p in all_output_paths}
+            for individual_job in job.jobs:
+                for p in individual_job.output:
+                    p_str = str(p)
+                    if p_str not in seen_paths:
+                        seen_paths.add(p_str)
+                        all_output_paths.append(p)
 
-        # Process script and notebook files from all rules in the job
-        # For grouped jobs, we need to iterate over job.jobs to access each individual
-        # job's rule which contains the script/notebook attributes.
-        # For individual jobs, job.rule directly has these attributes.
+        for path in all_output_paths:
+            self._add_file_if_transferable(
+                path,
+                transfer_output_files,
+                validate_exists=False,
+                warn_absolute=True,
+                skip_temp=True,
+            )
+
+        # Process script and notebook files from all rules in the job.
+        # For grouped jobs we iterate over job.jobs to reach each individual
+        # rule; for individual jobs the single rule lives on job.rule directly.
         if job.is_group():
-            # GroupJob: iterate over individual jobs within the group
-            individual_jobs = job.jobs if hasattr(job, "jobs") else []
-            for individual_job in individual_jobs:
-                if hasattr(individual_job, "rule"):
-                    rule = individual_job.rule
-                    if hasattr(rule, "script") and rule.script:
-                        self.logger.debug(
-                            f"Processing script from grouped job: {rule.script}"
-                        )
-                        self._add_file_if_transferable(
-                            rule.script,
-                            transfer_input_files,
-                            expand_wildcards=True,
-                            job=individual_job,
-                        )
-                    if hasattr(rule, "notebook") and rule.notebook:
-                        self.logger.debug(
-                            f"Processing notebook from grouped job: {rule.notebook}"
-                        )
-                        self._add_file_if_transferable(
-                            rule.notebook,
-                            transfer_input_files,
-                            expand_wildcards=True,
-                            job=individual_job,
-                        )
+            rules_and_jobs = [
+                (ij.rule, ij)
+                for ij in (job.jobs if hasattr(job, "jobs") else [])
+                if hasattr(ij, "rule")
+            ]
         else:
-            # Individual job: access rule directly
-            if hasattr(job, "rule"):
-                rule = job.rule
-                if hasattr(rule, "script") and rule.script:
-                    self.logger.debug(f"Processing script: {rule.script}")
+            rules_and_jobs = [(job.rule, job)] if hasattr(job, "rule") else []
+
+        for rule, owner_job in rules_and_jobs:
+            for attr in ("script", "notebook"):
+                if value := getattr(rule, attr, None):
+                    self.logger.debug(f"Processing {attr}: {value}")
                     self._add_file_if_transferable(
-                        rule.script,
+                        value,
                         transfer_input_files,
                         expand_wildcards=True,
-                        job=job,
-                    )
-                if hasattr(rule, "notebook") and rule.notebook:
-                    self.logger.debug(f"Processing notebook: {rule.notebook}")
-                    self._add_file_if_transferable(
-                        rule.notebook,
-                        transfer_input_files,
-                        expand_wildcards=True,
-                        job=job,
+                        job=owner_job,
                     )
 
         # Process additional input files from htcondor_transfer_input_files resource
@@ -628,6 +714,7 @@ class Executor(RemoteExecutor):
                     transfer_input_files,
                     expand_wildcards=expand_wildcards,
                     job=job,
+                    warn_absolute=True,
                 )
 
         # Process additional output files from htcondor_transfer_output_files resource
@@ -643,6 +730,7 @@ class Executor(RemoteExecutor):
                     expand_wildcards=expand_wildcards,
                     job=job,
                     validate_exists=False,
+                    warn_absolute=True,
                 )
 
         # Explicitly handle job_wrapper if specified
@@ -656,25 +744,33 @@ class Executor(RemoteExecutor):
                 job=job,
             )
 
+        # Build transfer_output_remaps for all output paths.
+        #
+        # For relative paths: remap to their absolute location under workdir_init
+        # so HTCondor places the file at the correct AP destination regardless of
+        # preserve_relative_paths semantics.
+        #
+        # For absolute paths: use an identity remap ("/abs/p = /abs/p") so
+        # HTCondor places the file at that exact absolute location on the AP
+        # rather than dropping it (by basename only) into the AP initial working
+        # directory — which is the default when no remap is present.
+        workdir = self.workflow.workdir_init
+        for out_path in transfer_output_files:
+            if isabs(out_path):
+                # Identity remap: EP absolute path → same absolute path on AP
+                remap = f"{out_path} = {out_path}"
+            else:
+                abs_ap_dest = normpath(join(workdir, out_path))
+                remap = f"{out_path} = {abs_ap_dest}"
+            if remap not in transfer_output_remaps:
+                transfer_output_remaps.append(remap)
+
         self.logger.debug(
             f"Transfer input files: {transfer_input_files}\n"
-            f"Transfer output files: {transfer_output_files}"
+            f"Transfer output files: {transfer_output_files}\n"
+            f"Transfer output remaps: {transfer_output_remaps}"
         )
-
-        # Warning for the absolute paths getting flattened after being sent to HTCondor
-        if job.resources.get("preserve_relative_paths", True):
-            abs_paths = [p for p in transfer_input_files if isabs(p)]
-            if abs_paths:
-                self.logger.warning(
-                    f"Input files contain absolute paths: {abs_paths}, "
-                    "which will be flattened to their basename on the EP. "
-                    "This can cause unexpected failures when "
-                    "preserve_relative_paths is True. "
-                    "Use relative paths in your Snakefile to preserve "
-                    "directory structure."
-                )
-
-        return transfer_input_files, transfer_output_files
+        return transfer_input_files, transfer_output_files, transfer_output_remaps
 
     def _prepare_config_files_for_transfer(
         self, job_args: str, shared_fs_prefixes: List[str]
@@ -869,7 +965,7 @@ class Executor(RemoteExecutor):
 
     def _get_exec_args_and_transfer_files(
         self, job: JobExecutorInterface, needs_transfer: bool
-    ) -> tuple[str, str, List[str], List[str]]:
+    ) -> tuple[str, str, List[str], List[str], List[str]]:
         """
         Get the executable, arguments, and transfer file lists for a job.
 
@@ -893,7 +989,9 @@ class Executor(RemoteExecutor):
             needs_transfer: Whether file transfer is needed (False for full shared FS)
 
         Returns:
-            Tuple of (executable, final_arguments, transfer_input_files, transfer_output_files)
+            Tuple of (executable, final_arguments, transfer_input_files,
+            transfer_output_files, transfer_output_remaps) where
+            transfer_output_remaps is a list of HTCondor remap strings.
         """
         # Get base executable and arguments
         job_exec, job_args = self._get_base_exec_and_args(job)
@@ -905,7 +1003,7 @@ class Executor(RemoteExecutor):
             self.logger.debug(
                 "Full shared filesystem mode - skipping transfer preparation"
             )
-            return job_exec, job_args, [], []
+            return job_exec, job_args, [], [], []
 
         # Modes 2 & 3: Need to prepare files for transfer
         if self.shared_fs_prefixes:
@@ -918,7 +1016,9 @@ class Executor(RemoteExecutor):
             )
 
         # Get files that need to be transferred (excludes config files)
-        transfer_input_files, transfer_output_files = self._get_files_for_transfer(job)
+        transfer_input_files, transfer_output_files, transfer_output_remaps = (
+            self._get_files_for_transfer(job)
+        )
 
         # Prepare config files - this modifies the arguments to use correct paths
         # and returns the list of config files to transfer
@@ -936,8 +1036,17 @@ class Executor(RemoteExecutor):
         self.logger.debug(
             f"Final transfer_output_files ({len(transfer_output_files)}): {transfer_output_files}"
         )
+        self.logger.debug(
+            f"Final transfer_output_remaps ({len(transfer_output_remaps)}): {transfer_output_remaps}"
+        )
 
-        return job_exec, job_args, transfer_input_files, transfer_output_files
+        return (
+            job_exec,
+            job_args,
+            transfer_input_files,
+            transfer_output_files,
+            transfer_output_remaps,
+        )
 
     def _set_resources(
         self, submit_dict: dict, job: JobExecutorInterface, key: str, default=None
@@ -967,9 +1076,13 @@ class Executor(RemoteExecutor):
         needs_transfer = not self.workflow.storage_settings.shared_fs_usage
 
         # Get executable, arguments (with adjusted config paths), and transfer file lists
-        job_exec, job_args, transfer_input_files, transfer_output_files = (
-            self._get_exec_args_and_transfer_files(job, needs_transfer)
-        )
+        (
+            job_exec,
+            job_args,
+            transfer_input_files,
+            transfer_output_files,
+            transfer_output_remaps,
+        ) = self._get_exec_args_and_transfer_files(job, needs_transfer)
 
         # Creating submit dictionary which is passed to htcondor.Submit
         submit_dict = {
@@ -1029,12 +1142,36 @@ class Executor(RemoteExecutor):
                     sorted(transfer_output_files)
                 )
 
+            if transfer_output_remaps:
+                self.logger.debug(f"Transfer output remaps: {transfer_output_remaps}")
+                submit_dict["transfer_output_remaps"] = "; ".join(
+                    transfer_output_remaps
+                )
+
         # Basic commands
         self._set_resources(submit_dict, job, "getenv", default=False)
 
         self._set_resources(submit_dict, job, "preserve_relative_paths", default=True)
 
-        for key in ["environment", "input", "max_materialize", "max_idle"]:
+        # Build the HTCondor environment string by merging:
+        #   1. Snakemake-managed env vars (storage plugin tokens, etc.) from self.envvars()
+        #   2. Any extra env vars the user declared via the `environment` job resource
+        # Using HTCondor's native `environment` key is strictly better than
+        # embedding "export VAR=val &&" in the arguments string, which breaks
+        # the job_wrapper code path (the args string must start cleanly with
+        # "python -m snakemake" for prefix-stripping to succeed).
+        env_parts = []
+        snakemake_env = self.envvars()
+        if snakemake_env:
+            env_parts.append(self._format_htcondor_environment(snakemake_env))
+        if user_env := job.resources.get("environment"):
+            # User-provided value is appended after Snakemake vars; user values
+            # for the same key will shadow ours (last assignment wins in HTCondor).
+            env_parts.append(str(user_env))
+        if env_parts:
+            submit_dict["environment"] = " ".join(env_parts)
+
+        for key in ["input", "max_materialize", "max_idle"]:
             self._set_resources(submit_dict, job, key)
 
         # Commands for matchmaking

--- a/tests/test_config_file_paths.py
+++ b/tests/test_config_file_paths.py
@@ -504,7 +504,7 @@ class TestFilesystemModes:
         - Arguments should remain unchanged (absolute paths are fine)
         - Transfer lists should be empty
         """
-        job_exec, job_args, transfer_in, transfer_out = (
+        job_exec, job_args, transfer_in, transfer_out, *_ = (
             self.executor._get_exec_args_and_transfer_files(
                 self.job, needs_transfer=False
             )
@@ -535,7 +535,7 @@ class TestFilesystemModes:
             "/home/user/project/nested/config.yaml",
         ]
 
-        job_exec, job_args, transfer_in, transfer_out = (
+        job_exec, job_args, transfer_in, transfer_out, *_ = (
             self.executor._get_exec_args_and_transfer_files(
                 self.job, needs_transfer=True
             )
@@ -566,7 +566,7 @@ class TestFilesystemModes:
             return_value="python -m snakemake --configfiles /home/user/project/local_config.yaml /staging/shared_config.yaml --cores 1"
         )
 
-        job_exec, job_args, transfer_in, transfer_out = (
+        job_exec, job_args, transfer_in, transfer_out, *_ = (
             self.executor._get_exec_args_and_transfer_files(
                 self.job, needs_transfer=True
             )

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,130 @@
+"""
+Tests for HTCondor environment variable handling.
+
+Covers:
+1. _format_htcondor_environment() serialization to HTCondor new-style format
+2. Verification that CommonSettings flags are configured correctly for the
+   HTCondor executor's environment injection strategy.
+"""
+
+from unittest.mock import Mock
+from snakemake_executor_plugin_htcondor import Executor, common_settings
+
+
+# ---------------------------------------------------------------------------
+# 1. _format_htcondor_environment() serialization
+# ---------------------------------------------------------------------------
+
+
+class TestFormatHtcondorEnvironment:
+    """Tests for _format_htcondor_environment() serialization."""
+
+    def setup_method(self):
+        self.executor = Mock(spec=Executor)
+        self.executor._format_htcondor_environment = (
+            Executor._format_htcondor_environment.__get__(self.executor, Executor)
+        )
+
+    def test_single_variable(self):
+        """Single key-value pair is serialized correctly."""
+        result = self.executor._format_htcondor_environment({"FOO": "bar"})
+        assert result == 'FOO="bar"'
+
+    def test_multiple_variables(self):
+        """Multiple variables are space-separated, each in KEY=\"value\" form."""
+        result = self.executor._format_htcondor_environment(
+            {"A": "1", "B": "2", "C": "3"}
+        )
+        assert 'A="1"' in result
+        assert 'B="2"' in result
+        assert 'C="3"' in result
+        # They should be space-separated
+        parts = result.split(" ")
+        assert len(parts) == 3
+
+    def test_empty_dict(self):
+        """An empty dict produces an empty string."""
+        result = self.executor._format_htcondor_environment({})
+        assert result == ""
+
+    def test_value_with_double_quotes_escaped(self):
+        """Double quotes inside values must be doubled for HTCondor."""
+        result = self.executor._format_htcondor_environment({"MSG": 'say "hello"'})
+        assert result == 'MSG="say ""hello"""'
+
+    def test_value_with_spaces(self):
+        """Values with spaces are properly quoted."""
+        result = self.executor._format_htcondor_environment(
+            {"PATH": "/usr/bin /usr/local/bin"}
+        )
+        assert result == 'PATH="/usr/bin /usr/local/bin"'
+
+    def test_value_with_equals_sign(self):
+        """Values containing = are properly quoted."""
+        result = self.executor._format_htcondor_environment({"OPTS": "key=value"})
+        assert result == 'OPTS="key=value"'
+
+    def test_non_string_value_coerced(self):
+        """Non-string values are coerced to strings."""
+        result = self.executor._format_htcondor_environment({"COUNT": 42, "FLAG": True})
+        assert 'COUNT="42"' in result
+        assert 'FLAG="True"' in result
+
+
+# ---------------------------------------------------------------------------
+# 2. CommonSettings flag correctness
+# ---------------------------------------------------------------------------
+
+
+class TestCommonSettingsFlags:
+    """Verify that CommonSettings flags are set correctly for the HTCondor executor."""
+
+    def test_pass_envvar_declarations_to_cmd_is_false(self):
+        """pass_envvar_declarations_to_cmd must be False.
+
+        When True, Snakemake embeds "export VAR=val &&" at the start of the
+        arguments string.  This breaks the job_wrapper code path because the
+        arguments string must start cleanly with "python -m snakemake" for
+        prefix-stripping to succeed.  Instead, the executor injects env vars
+        via HTCondor's native ``environment`` key in run_job().
+        """
+        assert common_settings.pass_envvar_declarations_to_cmd is False
+
+    def test_job_deploy_sources_is_false(self):
+        """job_deploy_sources must be False.
+
+        This setting only takes effect when can_transfer_local_files is False.
+        Since the HTCondor executor sets can_transfer_local_files=True (it handles
+        its own file transfers), job_deploy_sources is a dead letter.  Setting it
+        to False avoids confusion.
+        """
+        assert common_settings.job_deploy_sources is False
+
+    def test_can_transfer_local_files_is_true(self):
+        """can_transfer_local_files must be True.
+
+        This tells Snakemake that the executor handles its own file transfers
+        (via HTCondor's transfer_input_files / transfer_output_files), so
+        Snakemake should not require a default storage provider for local files.
+        """
+        assert common_settings.can_transfer_local_files is True
+
+    def test_non_local_exec_is_true(self):
+        """non_local_exec must be True — jobs run on remote execution points."""
+        assert common_settings.non_local_exec is True
+
+    def test_pass_default_storage_provider_args_is_true(self):
+        """pass_default_storage_provider_args must be True.
+
+        EP jobs need the --default-storage-provider and --default-storage-prefix
+        arguments so that storage-backed I/O works correctly on the remote side.
+        """
+        assert common_settings.pass_default_storage_provider_args is True
+
+    def test_pass_default_resources_args_is_true(self):
+        """pass_default_resources_args must be True.
+
+        EP jobs need the --default-resources arguments so that resource defaults
+        (e.g. tmpdir=$_CONDOR_SCRATCH_DIR) are propagated to remote execution.
+        """
+        assert common_settings.pass_default_resources_args is True

--- a/tests/test_no_shared_fs_hardening.py
+++ b/tests/test_no_shared_fs_hardening.py
@@ -1,0 +1,378 @@
+"""
+Tests for file-transfer hardening when running without a globally shared filesystem.
+
+Covers the two main fixes introduced in response to GitHub issue #48:
+
+1. Absolute-path warnings
+   When --shared-fs-usage is 'none' and a job declares an input or output file
+   with an absolute path that is not under any configured shared-fs prefix, the
+   executor should log a stern warning (but still attempt the submission).
+
+2. Explicit output-file transfer + transfer_output_remaps (mtime fix)
+   Previously the executor transferred only the *top-level directory* of each
+   output file (e.g. "output/" for "output/result.csv"), which meant that if the
+   same directory was used for both inputs *and* outputs of successive rules,
+   the whole directory was pushed back to the AP after the second rule, touching
+   the input files and invalidating Snakemake's mtime-based dependency tracking.
+
+   The fix is to declare each individual output file explicitly in
+   transfer_output_files and add a matching transfer_output_remaps entry so that
+   HTCondor places the file at its correct absolute location on the AP.
+"""
+
+from os.path import normpath, join
+from unittest.mock import Mock
+from snakemake_executor_plugin_htcondor import Executor
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_executor(workdir="/ap/workdir", shared_prefixes=None):
+    """Return a mock Executor with the methods under test bound to it."""
+    executor = Mock(spec=Executor)
+    executor.logger = Mock()
+    executor.shared_fs_prefixes = shared_prefixes or []
+    executor.workflow = Mock()
+    executor.workflow.configfiles = []
+    executor.workflow.workdir_init = workdir
+    executor.get_snakefile = Mock(return_value="Snakefile")
+
+    executor._get_files_for_transfer = Executor._get_files_for_transfer.__get__(
+        executor, Executor
+    )
+    executor._add_file_if_transferable = Executor._add_file_if_transferable.__get__(
+        executor, Executor
+    )
+    executor._parse_file_list = Executor._parse_file_list.__get__(executor, Executor)
+    return executor
+
+
+def _make_job(input_files=None, output_files=None, resources=None):
+    """Return a minimal mock individual job."""
+    job = Mock()
+    job.is_group = Mock(return_value=False)
+    job.name = "test_rule"
+    job.input = input_files or []
+    job.output = output_files or []
+    job.wildcards = {}
+    job.params = {}
+    job.rule = Mock()
+    job.rule.script = None
+    job.rule.notebook = None
+    job.format_wildcards = Mock(side_effect=lambda s, **kw: s)
+
+    _resources = resources or {}
+
+    def resource_get(key, default=None):
+        return _resources.get(key, default)
+
+    job.resources = Mock()
+    job.resources.get = Mock(side_effect=resource_get)
+    return job
+
+
+# ---------------------------------------------------------------------------
+# 1. Absolute-path warnings
+# ---------------------------------------------------------------------------
+
+
+class TestAbsolutePathWarnings:
+    """Absolute paths in job.input/output with no shared-fs prefix → warning."""
+
+    def setup_method(self):
+        self.executor = _make_executor()
+
+    # --- input files --------------------------------------------------------
+
+    def test_absolute_input_warns(self):
+        """Absolute input path not on shared FS should trigger a warning."""
+        job = _make_job(input_files=["/abs/data/input.csv"])
+        self.executor._get_files_for_transfer(job)
+
+        warning_calls = [str(c) for c in self.executor.logger.warning.call_args_list]
+        assert any(
+            "/abs/data/input.csv" in msg for msg in warning_calls
+        ), "Expected a warning about the absolute input path"
+
+    def test_absolute_input_still_added_to_transfer(self):
+        """Even with the warning, the absolute input is still queued for transfer
+        so the submission proceeds (warn-but-don't-block policy)."""
+        job = _make_job(input_files=["/abs/data/input.csv"])
+        transfer_input, *_ = self.executor._get_files_for_transfer(job)
+
+        assert "/abs/data/input.csv" in transfer_input
+
+    def test_relative_input_no_warning(self):
+        """Relative input paths must not trigger the absolute-path warning."""
+        job = _make_job(input_files=["data/input.csv"])
+        self.executor._get_files_for_transfer(job)
+
+        abs_path_warnings = [
+            str(c)
+            for c in self.executor.logger.warning.call_args_list
+            if "absolute path" in str(c)
+        ]
+        assert (
+            abs_path_warnings == []
+        ), f"Unexpected absolute-path warning for a relative file: {abs_path_warnings}"
+
+    def test_absolute_input_on_shared_fs_no_warning(self):
+        """Absolute input that lives under a shared-fs prefix must NOT warn."""
+        executor = _make_executor(shared_prefixes=["/staging/"])
+        job = _make_job(input_files=["/staging/project/input.csv"])
+        executor._get_files_for_transfer(job)
+
+        abs_path_warnings = [
+            str(c)
+            for c in executor.logger.warning.call_args_list
+            if "/staging/project/input.csv" in str(c)
+        ]
+        assert (
+            abs_path_warnings == []
+        ), "Expected no absolute-path warning for a shared-FS input file"
+
+    # --- output files -------------------------------------------------------
+
+    def test_absolute_output_warns(self):
+        """Absolute output path not on shared FS should trigger a warning."""
+        job = _make_job(output_files=["/abs/results/output.csv"])
+        self.executor._get_files_for_transfer(job)
+
+        warning_calls = [str(c) for c in self.executor.logger.warning.call_args_list]
+        assert any(
+            "/abs/results/output.csv" in msg for msg in warning_calls
+        ), "Expected a warning about the absolute output path"
+
+    def test_absolute_output_added_to_transfer_with_identity_remap(self):
+        """Absolute output paths that are not on shared FS are still queued for
+        transfer, together with an identity remap so HTCondor places the file at
+        the correct absolute location on the AP (not just the basename in IWD).
+        The job may well fail on the EP trying to write there, but it is strictly
+        better to *attempt* the transfer than to guarantee data loss."""
+        job = _make_job(output_files=["/abs/results/output.csv"])
+        _, transfer_output, remaps = self.executor._get_files_for_transfer(job)
+
+        assert "/abs/results/output.csv" in transfer_output
+        assert any("/abs/results/output.csv" in r for r in remaps)
+        # The remap must be an identity remap (same path on both sides)
+        matching = [r for r in remaps if "/abs/results/output.csv" in r]
+        assert len(matching) == 1
+        ep_side, ap_side = matching[0].split(" = ", 1)
+        assert ep_side.strip() == "/abs/results/output.csv"
+        assert ap_side.strip() == "/abs/results/output.csv"
+
+    def test_absolute_output_on_shared_fs_no_warning_and_not_transferred(self):
+        """Absolute output that is on a shared-fs prefix must not warn and
+        must not appear in the transfer list (no transfer needed)."""
+        executor = _make_executor(shared_prefixes=["/staging/"])
+        job = _make_job(output_files=["/staging/results/output.csv"])
+        _, transfer_output, transfer_remaps = executor._get_files_for_transfer(job)
+
+        abs_path_warnings = [
+            str(c)
+            for c in executor.logger.warning.call_args_list
+            if "/staging/results/output.csv" in str(c)
+        ]
+        assert (
+            abs_path_warnings == []
+        ), "Expected no absolute-path warning for a shared-FS output file"
+        assert "/staging/results/output.csv" not in transfer_output
+        assert len(transfer_remaps) == 0
+
+    def test_mixed_absolute_and_relative_outputs(self):
+        """Mixed output list: relative files use a workdir remap, absolute ones
+        are warned about but still transferred with an identity remap."""
+        job = _make_job(
+            output_files=[
+                "output/good.csv",  # relative → workdir remap
+                "/abs/bad.csv",  # absolute, not shared → warned + identity remap
+            ]
+        )
+        _, transfer_output, remaps = self.executor._get_files_for_transfer(job)
+
+        assert "output/good.csv" in transfer_output
+        assert "/abs/bad.csv" in transfer_output
+
+        # Relative output → absolute AP destination remap
+        assert any("output/good.csv" in r and "/ap/workdir" in r for r in remaps)
+        # Absolute output → identity remap
+        assert any("/abs/bad.csv = /abs/bad.csv" in r for r in remaps)
+
+        warning_calls = [str(c) for c in self.executor.logger.warning.call_args_list]
+        assert any("/abs/bad.csv" in msg for msg in warning_calls)
+
+    # --- htcondor_transfer_input_files resource ------------------------------
+
+    def test_absolute_custom_input_resource_warns(self):
+        """htcondor_transfer_input_files with an absolute path should also warn."""
+        job = _make_job(resources={"htcondor_transfer_input_files": "/abs/helper.py"})
+        job.format_wildcards = Mock(side_effect=lambda s, **kw: s)
+        self.executor._get_files_for_transfer(job)
+
+        warning_calls = [str(c) for c in self.executor.logger.warning.call_args_list]
+        assert any("/abs/helper.py" in msg for msg in warning_calls)
+
+
+# ---------------------------------------------------------------------------
+# 2. Explicit output-file transfer (mtime fix)
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitOutputTransfer:
+    """Output files are transferred explicitly, not as top-level directories."""
+
+    def setup_method(self):
+        self.executor = _make_executor()
+
+    def test_single_relative_output_transferred_explicitly(self):
+        """A single relative output file must appear as-is in transfer list."""
+        job = _make_job(output_files=["output/result.csv"])
+        _, transfer_output, _ = self.executor._get_files_for_transfer(job)
+
+        assert "output/result.csv" in transfer_output
+        # The parent directory must NOT be in the list
+        assert "output" not in transfer_output
+
+    def test_nested_relative_output_transferred_explicitly(self):
+        """Deeply nested relative outputs are listed verbatim."""
+        job = _make_job(output_files=["a/b/c/deep.txt"])
+        _, transfer_output, _ = self.executor._get_files_for_transfer(job)
+
+        assert "a/b/c/deep.txt" in transfer_output
+        assert "a" not in transfer_output
+
+    def test_multiple_outputs_same_directory_all_listed(self):
+        """All explicit output files are listed even when they share a directory."""
+        job = _make_job(
+            output_files=["output/file1.csv", "output/file2.csv", "output/file3.csv"]
+        )
+        _, transfer_output, _ = self.executor._get_files_for_transfer(job)
+
+        assert "output/file1.csv" in transfer_output
+        assert "output/file2.csv" in transfer_output
+        assert "output/file3.csv" in transfer_output
+        assert "output" not in transfer_output
+
+    def test_overlapping_input_output_directory_mtime_regression(self):
+        """Key regression test for the mtime bug.
+
+        When rule 2's inputs live in the same directory as rule 2's outputs
+        (because that directory was rule 1's output), the old executor would
+        transfer the whole directory back to the AP, touching rule 2's inputs
+        and breaking Snakemake's mtime check.
+
+        With the fix, only rule 2's explicit output files are declared for
+        transfer, so rule 2's inputs (which also live in output/) are untouched
+        on the AP.
+        """
+        # Simulate rule 2: reads output/step1.csv (rule 1's output),
+        # writes output/step2.csv (rule 2's output).  Both live in output/.
+        job = _make_job(
+            input_files=["output/step1.csv"],
+            output_files=["output/step2.csv"],
+        )
+        _, transfer_output, _ = self.executor._get_files_for_transfer(job)
+
+        # Only the explicit output should be declared for back-transfer
+        assert "output/step2.csv" in transfer_output
+        # The parent directory must NOT appear — that would touch step1.csv too
+        assert "output" not in transfer_output
+
+    def test_output_deduplication(self):
+        """Duplicate output paths in job.output are only transferred once."""
+        job = _make_job(output_files=["output/result.csv", "output/result.csv"])
+        _, transfer_output, _ = self.executor._get_files_for_transfer(job)
+
+        assert transfer_output.count("output/result.csv") == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. transfer_output_remaps generation
+# ---------------------------------------------------------------------------
+
+
+class TestOutputRemaps:
+    """transfer_output_remaps maps each EP output path to its AP absolute path."""
+
+    def setup_method(self):
+        self.workdir = "/ap/workdir"
+        self.executor = _make_executor(workdir=self.workdir)
+
+    def test_remap_generated_for_relative_output(self):
+        """Every relative output file must have a corresponding remap entry."""
+        job = _make_job(output_files=["output/result.csv"])
+        _, _, remaps = self.executor._get_files_for_transfer(job)
+
+        assert len(remaps) == 1
+        ep_side, ap_side = remaps[0].split(" = ")
+        assert ep_side.strip() == "output/result.csv"
+        assert ap_side.strip() == normpath(join(self.workdir, "output/result.csv"))
+
+    def test_remap_destination_is_absolute(self):
+        """The AP-side remap destination must always be an absolute path."""
+        job = _make_job(output_files=["results/model.pkl"])
+        _, _, remaps = self.executor._get_files_for_transfer(job)
+
+        for remap in remaps:
+            _, dest = remap.split(" = ", 1)
+            assert dest.strip().startswith(
+                "/"
+            ), f"Remap AP destination should be absolute: {remap}"
+
+    def test_remap_count_matches_output_file_count(self):
+        """One remap per output file (excluding shared-FS and absolute outputs)."""
+        job = _make_job(
+            output_files=[
+                "out/a.txt",
+                "out/b.txt",
+                "out/c.txt",
+            ]
+        )
+        _, transfer_output, remaps = self.executor._get_files_for_transfer(job)
+
+        assert len(remaps) == len(transfer_output)
+
+    def test_no_remap_for_shared_fs_output(self):
+        """Outputs on a shared FS are skipped entirely — no remap generated."""
+        executor = _make_executor(shared_prefixes=["/staging/"])
+        job = _make_job(output_files=["/staging/results/out.csv"])
+        _, transfer_output, remaps = executor._get_files_for_transfer(job)
+
+        assert len(transfer_output) == 0
+        assert len(remaps) == 0
+
+    def test_identity_remap_for_absolute_output(self):
+        """Absolute outputs not on shared FS get an identity remap
+        ('/abs/path = /abs/path') so HTCondor returns the file to the correct
+        absolute location on the AP instead of the basename in IWD."""
+        job = _make_job(output_files=["/abs/output/file.csv"])
+        _, transfer_output, remaps = self.executor._get_files_for_transfer(job)
+
+        assert "/abs/output/file.csv" in transfer_output
+        assert len(remaps) == 1
+        ep_side, ap_side = remaps[0].split(" = ", 1)
+        assert ep_side.strip() == "/abs/output/file.csv"
+        assert ap_side.strip() == "/abs/output/file.csv"
+
+    def test_remap_uses_normpath(self):
+        """The AP-side destination is normalised (no trailing slashes, etc.)."""
+        job = _make_job(output_files=["output/../output/result.csv"])
+        _, _, remaps = self.executor._get_files_for_transfer(job)
+
+        assert len(remaps) == 1
+        ep_side, ap_side = remaps[0].split(" = ", 1)
+        # normpath should collapse the ..
+        assert ".." not in ep_side.strip()
+        assert ".." not in ap_side.strip()
+
+    def test_remap_for_custom_output_resource(self):
+        """htcondor_transfer_output_files relative paths also get remaps."""
+        job = _make_job(resources={"htcondor_transfer_output_files": "logs/run.log"})
+        job.format_wildcards = Mock(side_effect=lambda s, **kw: s)
+        _, transfer_output, remaps = self.executor._get_files_for_transfer(job)
+
+        assert "logs/run.log" in transfer_output
+        assert any("logs/run.log" in r for r in remaps)


### PR DESCRIPTION
Apologies for the bad git etiquette in that I'm lumping together multiple changes in a single commit.

This "hardening" of file transfers continues to whittle away at various issues related to file transfers. It also bundles a few other relatively small changes.

In particular, it attempts to accomplish:
- output files are now transferred individually instead of handled at the directory level (to avoid issues with mtime updates at the AP)
- Snakemake env vars are passed to jobs via the Condor submit description instead of passing environment via the snake job's arguments. I also audited other `CommonSettings` and set `job_deploy_sources=False` because I found that flag is a no-op when the executor can transfer local files.
- Temp outputs are excluded from transfer.